### PR TITLE
[FLINK-29750][Connector/JDBC] Improve PostgresCatalog#listTables() by reusing resources

### DIFF
--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/AbstractJdbcCatalog.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/AbstractJdbcCatalog.java
@@ -497,29 +497,35 @@ public abstract class AbstractJdbcCatalog extends AbstractCatalog {
             Predicate<String> filterFunc,
             Object... params) {
 
-        List<String> columnValues = Lists.newArrayList();
-
         try (Connection conn = DriverManager.getConnection(connUrl, username, pwd);
                 PreparedStatement ps = conn.prepareStatement(sql)) {
-            if (Objects.nonNull(params) && params.length > 0) {
-                for (int i = 0; i < params.length; i++) {
-                    ps.setObject(i + 1, params[i]);
-                }
-            }
-            ResultSet rs = ps.executeQuery();
-            while (rs.next()) {
-                String columnValue = rs.getString(columnIndex);
-                if (Objects.isNull(filterFunc) || filterFunc.test(columnValue)) {
-                    columnValues.add(columnValue);
-                }
-            }
-            return columnValues;
+            return extractColumnValuesByStatement(ps, columnIndex, filterFunc, params);
+
         } catch (Exception e) {
             throw new CatalogException(
                     String.format(
                             "The following SQL query could not be executed (%s): %s", connUrl, sql),
                     e);
         }
+    }
+
+    protected static List<String> extractColumnValuesByStatement(
+            PreparedStatement ps, int columnIndex, Predicate<String> filterFunc, Object... params)
+            throws SQLException {
+        List<String> columnValues = Lists.newArrayList();
+        if (Objects.nonNull(params) && params.length > 0) {
+            for (int i = 0; i < params.length; i++) {
+                ps.setObject(i + 1, params[i]);
+            }
+        }
+        ResultSet rs = ps.executeQuery();
+        while (rs.next()) {
+            String columnValue = rs.getString(columnIndex);
+            if (Objects.isNull(filterFunc) || filterFunc.test(columnValue)) {
+                columnValues.add(columnValue);
+            }
+        }
+        return columnValues;
     }
 
     protected DataType fromJDBCType(ObjectPath tablePath, ResultSetMetaData metadata, int colIndex)

--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/AbstractJdbcCatalog.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/AbstractJdbcCatalog.java
@@ -518,11 +518,12 @@ public abstract class AbstractJdbcCatalog extends AbstractCatalog {
                 ps.setObject(i + 1, params[i]);
             }
         }
-        ResultSet rs = ps.executeQuery();
-        while (rs.next()) {
-            String columnValue = rs.getString(columnIndex);
-            if (Objects.isNull(filterFunc) || filterFunc.test(columnValue)) {
-                columnValues.add(columnValue);
+        try (ResultSet rs = ps.executeQuery()) {
+            while (rs.next()) {
+                String columnValue = rs.getString(columnIndex);
+                if (Objects.isNull(filterFunc) || filterFunc.test(columnValue)) {
+                    columnValues.add(columnValue);
+                }
             }
         }
         return columnValues;


### PR DESCRIPTION
## What is the purpose of the change

Currently the `PostgresCatalog#listTables()` creates a new connection and prepared statement for every schema and table when listing tables. This can be optimized by reusing those resources.


## Brief change log

*(for example:)*
  - Introduce `extractColumnValuesByStatement` in base class `AbstractJdbcCatalog`
  - Reuse connection and prepared in `PostgresCatalog#listTables()`

This is moved from apache/flink#21146