### PR TITLE
[FLINK-28466][tests] Update assertj to 3.23.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@ under the License.
         <jackson-bom.version>2.13.4.20221013</jackson-bom.version>
         <junit4.version>4.13.2</junit4.version>
         <junit5.version>5.8.1</junit5.version>
-        <assertj.version>3.21.0</assertj.version>
+        <assertj.version>3.23.1</assertj.version>
         <archunit.version>0.22.0</archunit.version>
         <testcontainers.version>1.17.2</testcontainers.version>
         <mockito.version>2.21.0</mockito.version>
@@ -114,6 +114,16 @@ under the License.
             <version>${mockito.version}</version>
             <type>jar</type>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.bytebuddy</groupId>
+                    <artifactId>byte-buddy</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>net.bytebuddy</groupId>
+                    <artifactId>byte-buddy-agent</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This is almost a cherry pick from flink master + exclusion of `byte-buddy` to avoid dependency convergence