### PR TITLE
[FLINK-30576] Refactor JdbcOutputFormat to use ExecutionConfig

### DIFF
--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/JdbcRowOutputFormat.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/JdbcRowOutputFormat.java
@@ -19,7 +19,7 @@
 package org.apache.flink.connector.jdbc;
 
 import org.apache.flink.annotation.Experimental;
-import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.connector.jdbc.internal.JdbcOutputFormat;
 import org.apache.flink.connector.jdbc.internal.connection.JdbcConnectionProvider;
 import org.apache.flink.connector.jdbc.internal.connection.SimpleJdbcConnectionProvider;
@@ -53,18 +53,18 @@ public class JdbcRowOutputFormat
         super(
                 connectionProvider,
                 new JdbcExecutionOptions.Builder().withBatchSize(batchSize).build(),
-                ctx -> createRowExecutor(sql, typesArray, ctx),
+                config -> createRowExecutor(sql, typesArray, config),
                 JdbcOutputFormat.RecordExtractor.identity());
     }
 
     private static JdbcBatchStatementExecutor<Row> createRowExecutor(
-            String sql, int[] typesArray, RuntimeContext ctx) {
+            String sql, int[] typesArray, ExecutionConfig config) {
         JdbcStatementBuilder<Row> statementBuilder =
                 (st, record) -> setRecordToStatement(st, typesArray, record);
         return JdbcBatchStatementExecutor.simple(
                 sql,
                 statementBuilder,
-                ctx.getExecutionConfig().isObjectReuseEnabled() ? Row::copy : Function.identity());
+                config.isObjectReuseEnabled() ? Row::copy : Function.identity());
     }
 
     public static JdbcOutputFormatBuilder buildJdbcOutputFormat() {

--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/GenericJdbcSinkFunction.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/GenericJdbcSinkFunction.java
@@ -20,7 +20,6 @@ package org.apache.flink.connector.jdbc.internal;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.InputTypeConfigurable;
 import org.apache.flink.configuration.Configuration;
@@ -47,9 +46,7 @@ public class GenericJdbcSinkFunction<T> extends RichSinkFunction<T>
     @Override
     public void open(Configuration parameters) throws Exception {
         super.open(parameters);
-        RuntimeContext ctx = getRuntimeContext();
-        outputFormat.setRuntimeContext(ctx);
-        outputFormat.open(ctx.getIndexOfThisSubtask(), ctx.getNumberOfParallelSubtasks());
+        outputFormat.open(getRuntimeContext().getExecutionConfig());
     }
 
     @Override

--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/xa/JdbcXaSinkFunction.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/xa/JdbcXaSinkFunction.java
@@ -239,11 +239,9 @@ public class JdbcXaSinkFunction<T> extends AbstractRichFunction
             xaGroupOps.recoverAndRollback(getRuntimeContext(), xidGenerator);
         }
         beginTx(0L);
-        outputFormat.setRuntimeContext(getRuntimeContext());
+
         // open format only after starting the transaction so it gets a ready to  use connection
-        outputFormat.open(
-                getRuntimeContext().getIndexOfThisSubtask(),
-                getRuntimeContext().getNumberOfParallelSubtasks());
+        outputFormat.open(getRuntimeContext().getExecutionConfig());
     }
 
     @Override

--- a/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/JdbcDataTestBase.java
+++ b/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/JdbcDataTestBase.java
@@ -17,21 +17,16 @@
 
 package org.apache.flink.connector.jdbc;
 
-import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.functions.RuntimeContext;
-import org.apache.flink.connector.jdbc.internal.JdbcOutputFormat;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.types.Row;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.mockito.Mockito;
 
 import java.sql.SQLException;
 
 import static org.apache.flink.connector.jdbc.JdbcTestFixture.DERBY_EBOOKSHOP_DB;
-import static org.mockito.Mockito.doReturn;
 
 /**
  * Base class for JDBC test using data from {@link JdbcTestFixture}. It uses {@link DerbyDbMetadata}
@@ -69,13 +64,5 @@ public abstract class JdbcDataTestBase extends JdbcTestBase {
             }
         }
         return row;
-    }
-
-    public static void setRuntimeContext(JdbcOutputFormat format, Boolean reused) {
-        RuntimeContext context = Mockito.mock(RuntimeContext.class);
-        ExecutionConfig config = Mockito.mock(ExecutionConfig.class);
-        doReturn(config).when(context).getExecutionConfig();
-        doReturn(reused).when(config).isObjectReuseEnabled();
-        format.setRuntimeContext(context);
     }
 }

--- a/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/JdbcRowOutputFormatTest.java
+++ b/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/JdbcRowOutputFormatTest.java
@@ -79,7 +79,7 @@ class JdbcRowOutputFormatTest extends JdbcDataTestBase {
                             .setDBUrl(DERBY_EBOOKSHOP_DB.getUrl())
                             .setQuery(String.format(INSERT_TEMPLATE, INPUT_TABLE))
                             .finish();
-            jdbcOutputFormat.open(0, 1);
+            jdbcOutputFormat.open(getExecutionConfig(false));
         } catch (Exception e) {
             assertThat(findThrowable(e, IOException.class)).isPresent();
             assertThat(findThrowableWithMessage(e, expectedMsg)).isPresent();
@@ -96,7 +96,7 @@ class JdbcRowOutputFormatTest extends JdbcDataTestBase {
                         .setDBUrl("jdbc:der:iamanerror:mory:ebookshop")
                         .setQuery(String.format(INSERT_TEMPLATE, INPUT_TABLE))
                         .finish();
-        assertThatThrownBy(() -> jdbcOutputFormat.open(0, 1))
+        assertThatThrownBy(() -> jdbcOutputFormat.open(getExecutionConfig(false)))
                 .isInstanceOf(IOException.class)
                 .satisfies(anyCauseMatches(SQLException.class, expectedMsg));
     }
@@ -111,8 +111,7 @@ class JdbcRowOutputFormatTest extends JdbcDataTestBase {
                             .setDBUrl(DERBY_EBOOKSHOP_DB.getUrl())
                             .setQuery("iamnotsql")
                             .finish();
-            setRuntimeContext(jdbcOutputFormat, true);
-            jdbcOutputFormat.open(0, 1);
+            jdbcOutputFormat.open(getExecutionConfig(true));
         } catch (Exception e) {
             assertThat(findThrowable(e, IOException.class)).isPresent();
             assertThat(findThrowableWithMessage(e, expectedMsg)).isPresent();
@@ -144,8 +143,7 @@ class JdbcRowOutputFormatTest extends JdbcDataTestBase {
                             .setDBUrl(DERBY_EBOOKSHOP_DB.getUrl())
                             .setQuery(String.format(INSERT_TEMPLATE, INPUT_TABLE))
                             .finish();
-            setRuntimeContext(jdbcOutputFormat, true);
-            jdbcOutputFormat.open(0, 1);
+            jdbcOutputFormat.open(getExecutionConfig(true));
 
             Row row = new Row(5);
             row.setField(0, 4);
@@ -180,8 +178,7 @@ class JdbcRowOutputFormatTest extends JdbcDataTestBase {
                                         Types.INTEGER
                                     })
                             .finish();
-            setRuntimeContext(jdbcOutputFormat, true);
-            jdbcOutputFormat.open(0, 1);
+            jdbcOutputFormat.open(getExecutionConfig(true));
 
             TestEntry entry = TEST_DATA[0];
             Row row = new Row(5);
@@ -216,8 +213,7 @@ class JdbcRowOutputFormatTest extends JdbcDataTestBase {
                                         Types.INTEGER
                                     })
                             .finish();
-            setRuntimeContext(jdbcOutputFormat, true);
-            jdbcOutputFormat.open(0, 1);
+            jdbcOutputFormat.open(getExecutionConfig(true));
 
             TestEntry entry = TEST_DATA[0];
             Row row = new Row(5);
@@ -245,8 +241,7 @@ class JdbcRowOutputFormatTest extends JdbcDataTestBase {
                         .setDBUrl(DERBY_EBOOKSHOP_DB.getUrl())
                         .setQuery(String.format(INSERT_TEMPLATE, OUTPUT_TABLE))
                         .finish();
-        setRuntimeContext(jdbcOutputFormat, true);
-        jdbcOutputFormat.open(0, 1);
+        jdbcOutputFormat.open(getExecutionConfig(true));
 
         for (TestEntry entry : TEST_DATA) {
             jdbcOutputFormat.writeRecord(toRow(entry));
@@ -280,10 +275,10 @@ class JdbcRowOutputFormatTest extends JdbcDataTestBase {
                         .setQuery(String.format(INSERT_TEMPLATE, OUTPUT_TABLE_2))
                         .setBatchSize(3)
                         .finish();
-        setRuntimeContext(jdbcOutputFormat, true);
+
         try (Connection dbConn = DriverManager.getConnection(DERBY_EBOOKSHOP_DB.getUrl());
                 PreparedStatement statement = dbConn.prepareStatement(SELECT_ALL_NEWBOOKS_2)) {
-            jdbcOutputFormat.open(0, 1);
+            jdbcOutputFormat.open(getExecutionConfig(true));
             for (int i = 0; i < 2; ++i) {
                 jdbcOutputFormat.writeRecord(toRow(TEST_DATA[i]));
             }
@@ -319,8 +314,7 @@ class JdbcRowOutputFormatTest extends JdbcDataTestBase {
                         .setDBUrl(DERBY_EBOOKSHOP_DB.getUrl())
                         .setQuery(String.format(INSERT_TEMPLATE, OUTPUT_TABLE_3))
                         .finish();
-        setRuntimeContext(jdbcOutputFormat, true);
-        jdbcOutputFormat.open(0, 1);
+        jdbcOutputFormat.open(getExecutionConfig(true));
 
         // write records
         for (int i = 0; i < 3; i++) {

--- a/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/JdbcTestBase.java
+++ b/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/JdbcTestBase.java
@@ -17,8 +17,13 @@
 
 package org.apache.flink.connector.jdbc;
 
+import org.apache.flink.api.common.ExecutionConfig;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mockito;
+
+import static org.mockito.Mockito.doReturn;
 
 /**
  * Base class for JDBC test using DDL from {@link JdbcTestFixture}. It uses create tables before
@@ -38,4 +43,10 @@ public abstract class JdbcTestBase {
     }
 
     protected abstract DbMetadata getDbMetadata();
+
+    public static ExecutionConfig getExecutionConfig(Boolean reused) {
+        ExecutionConfig config = Mockito.mock(ExecutionConfig.class);
+        doReturn(reused).when(config).isObjectReuseEnabled();
+        return config;
+    }
 }

--- a/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/internal/JdbcFullTest.java
+++ b/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/internal/JdbcFullTest.java
@@ -18,11 +18,11 @@
 
 package org.apache.flink.connector.jdbc.internal;
 
-import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.io.OutputFormat;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.jdbc.JdbcConnectionOptions;
 import org.apache.flink.connector.jdbc.JdbcDataTestBase;
 import org.apache.flink.connector.jdbc.JdbcExecutionOptions;
@@ -36,8 +36,8 @@ import org.apache.flink.types.Row;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
+import java.io.IOException;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -57,7 +57,6 @@ import static org.apache.flink.connector.jdbc.utils.JdbcUtils.setRecordToStateme
 import static org.apache.flink.util.ExceptionUtils.findThrowable;
 import static org.apache.flink.util.ExceptionUtils.findThrowableWithMessage;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.doReturn;
 
 /** Tests using both {@link JdbcInputFormat} and {@link JdbcOutputFormat}. */
 class JdbcFullTest extends JdbcDataTestBase {
@@ -94,13 +93,8 @@ class JdbcFullTest extends JdbcDataTestBase {
                                     })
                             .setKeyFields(null)
                             .build();
-            RuntimeContext context = Mockito.mock(RuntimeContext.class);
-            ExecutionConfig config = Mockito.mock(ExecutionConfig.class);
-            doReturn(config).when(context).getExecutionConfig();
-            doReturn(true).when(config).isObjectReuseEnabled();
-            jdbcOutputFormat.setRuntimeContext(context);
 
-            jdbcOutputFormat.open(1, 1);
+            jdbcOutputFormat.open(getExecutionConfig(true));
             Row inputRow = Row.of(1001, "Java public for dummies", "Tan Ah Teck", "11.11", 11);
             jdbcOutputFormat.writeRecord(Tuple2.of(true, inputRow));
             jdbcOutputFormat.close();
@@ -142,11 +136,11 @@ class JdbcFullTest extends JdbcDataTestBase {
                         .withDriverName(getDbMetadata().getDriverClass())
                         .build();
 
-        JdbcOutputFormat jdbcOutputFormat =
+        JdbcOutputFormat<Row, ?, ?> jdbcOutputFormat =
                 new JdbcOutputFormat<>(
                         new SimpleJdbcConnectionProvider(connectionOptions),
                         JdbcExecutionOptions.defaults(),
-                        ctx ->
+                        config ->
                                 createSimpleRowExecutor(
                                         String.format(INSERT_TEMPLATE, OUTPUT_TABLE),
                                         new int[] {
@@ -156,10 +150,10 @@ class JdbcFullTest extends JdbcDataTestBase {
                                             Types.DOUBLE,
                                             Types.INTEGER
                                         },
-                                        ctx.getExecutionConfig().isObjectReuseEnabled()),
+                                        config.isObjectReuseEnabled()),
                         JdbcOutputFormat.RecordExtractor.identity());
 
-        source.output(jdbcOutputFormat);
+        source.output(new TestOutputFormat(jdbcOutputFormat));
         environment.execute();
 
         try (Connection dbConn = DriverManager.getConnection(getDbMetadata().getUrl());
@@ -191,5 +185,31 @@ class JdbcFullTest extends JdbcDataTestBase {
                 (st, record) -> setRecordToStatement(st, fieldTypes, record);
         return JdbcBatchStatementExecutor.simple(
                 sql, builder, objectReuse ? Row::copy : Function.identity());
+    }
+
+    public static class TestOutputFormat implements OutputFormat<Row> {
+        private final JdbcOutputFormat<Row, ?, ?> jdbcOutputFormat;
+
+        public TestOutputFormat(JdbcOutputFormat<Row, ?, ?> jdbcOutputFormat) {
+            this.jdbcOutputFormat = jdbcOutputFormat;
+        }
+
+        @Override
+        public void configure(Configuration configuration) {}
+
+        @Override
+        public void open(int i, int i1) throws IOException {
+            this.jdbcOutputFormat.open(getExecutionConfig(false));
+        }
+
+        @Override
+        public void writeRecord(Row row) throws IOException {
+            this.jdbcOutputFormat.writeRecord(row);
+        }
+
+        @Override
+        public void close() throws IOException {
+            this.jdbcOutputFormat.close();
+        }
     }
 }

--- a/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/internal/JdbcTableOutputFormatTest.java
+++ b/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/internal/JdbcTableOutputFormatTest.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.connector.jdbc.internal;
 
-import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.connector.jdbc.JdbcDataTestBase;
 import org.apache.flink.connector.jdbc.JdbcExecutionOptions;
@@ -32,7 +30,6 @@ import org.apache.flink.types.Row;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -48,7 +45,6 @@ import static org.apache.flink.connector.jdbc.JdbcTestFixture.OUTPUT_TABLE;
 import static org.apache.flink.connector.jdbc.JdbcTestFixture.TEST_DATA;
 import static org.apache.flink.connector.jdbc.JdbcTestFixture.TestEntry;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.doReturn;
 
 /** Tests for the {@link JdbcOutputFormat}. */
 public class JdbcTableOutputFormatTest extends JdbcDataTestBase {
@@ -154,12 +150,8 @@ public class JdbcTableOutputFormatTest extends JdbcDataTestBase {
                                     @Override
                                     public void closeStatements() {}
                                 });
-        RuntimeContext context = Mockito.mock(RuntimeContext.class);
-        ExecutionConfig config = Mockito.mock(ExecutionConfig.class);
-        doReturn(config).when(context).getExecutionConfig();
-        doReturn(true).when(config).isObjectReuseEnabled();
-        format.setRuntimeContext(context);
-        format.open(0, 1);
+
+        format.open(getExecutionConfig(true));
 
         format.writeRecord(Tuple2.of(false /* false = delete*/, toRow(TEST_DATA[0])));
         format.flush();
@@ -189,12 +181,8 @@ public class JdbcTableOutputFormatTest extends JdbcDataTestBase {
                         new SimpleJdbcConnectionProvider(options),
                         dmlOptions,
                         JdbcExecutionOptions.defaults());
-        RuntimeContext context = Mockito.mock(RuntimeContext.class);
-        ExecutionConfig config = Mockito.mock(ExecutionConfig.class);
-        doReturn(config).when(context).getExecutionConfig();
-        doReturn(true).when(config).isObjectReuseEnabled();
-        format.setRuntimeContext(context);
-        format.open(0, 1);
+
+        format.open(getExecutionConfig(true));
 
         for (TestEntry entry : TEST_DATA) {
             format.writeRecord(Tuple2.of(true, toRow(entry)));

--- a/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcAppendOnlyWriterTest.java
+++ b/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcAppendOnlyWriterTest.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.connector.jdbc.table;
 
-import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.connector.jdbc.DbMetadata;
 import org.apache.flink.connector.jdbc.JdbcTestBase;
@@ -30,7 +28,6 @@ import org.apache.flink.connector.jdbc.internal.options.JdbcConnectorOptions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.sql.Connection;
@@ -43,7 +40,6 @@ import static org.apache.flink.connector.jdbc.JdbcTestFixture.OUTPUT_TABLE;
 import static org.apache.flink.connector.jdbc.JdbcTestFixture.TEST_DATA;
 import static org.apache.flink.connector.jdbc.JdbcTestFixture.TestEntry;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.doReturn;
 
 /** Test for the Append only mode. */
 class JdbcAppendOnlyWriterTest extends JdbcTestBase {
@@ -76,12 +72,8 @@ class JdbcAppendOnlyWriterTest extends JdbcTestBase {
                                             .setFieldNames(fieldNames)
                                             .setKeyFields(null)
                                             .build();
-                            RuntimeContext context = Mockito.mock(RuntimeContext.class);
-                            ExecutionConfig config = Mockito.mock(ExecutionConfig.class);
-                            doReturn(config).when(context).getExecutionConfig();
-                            doReturn(true).when(config).isObjectReuseEnabled();
-                            format.setRuntimeContext(context);
-                            format.open(0, 1);
+
+                            format.open(getExecutionConfig(true));
 
                             // alter table schema to trigger retry logic after failure.
                             alterTable();

--- a/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcOutputFormatTest.java
+++ b/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcOutputFormatTest.java
@@ -110,7 +110,7 @@ class JdbcOutputFormatTest extends JdbcDataTestBase {
                                             .setJdbcExecutionOptions(
                                                     JdbcExecutionOptions.builder().build())
                                             .build();
-                            outputFormat.open(0, 1);
+                            outputFormat.open(getExecutionConfig(false));
                         })
                 .isInstanceOf(IOException.class)
                 .hasMessage(expectedMsg);
@@ -141,7 +141,7 @@ class JdbcOutputFormatTest extends JdbcDataTestBase {
                                             .setJdbcExecutionOptions(
                                                     JdbcExecutionOptions.builder().build())
                                             .build();
-                            outputFormat.open(0, 1);
+                            outputFormat.open(getExecutionConfig(false));
                         })
                 .isInstanceOf(IllegalStateException.class);
     }
@@ -173,8 +173,7 @@ class JdbcOutputFormatTest extends JdbcDataTestBase {
                                             .setRowDataTypeInfo(rowDataTypeInfo)
                                             .build();
 
-                            setRuntimeContext(outputFormat, false);
-                            outputFormat.open(0, 1);
+                            outputFormat.open(getExecutionConfig(false));
 
                             RowData row =
                                     buildGenericData(4, "hello", "world", 0.99, "imthewrongtype");
@@ -211,8 +210,8 @@ class JdbcOutputFormatTest extends JdbcDataTestBase {
                                                     JdbcExecutionOptions.builder().build())
                                             .setRowDataTypeInfo(rowDataTypeInfo)
                                             .build();
-                            setRuntimeContext(outputFormat, false);
-                            outputFormat.open(0, 1);
+
+                            outputFormat.open(getExecutionConfig(false));
 
                             TestEntry entry = TEST_DATA[0];
                             RowData row =
@@ -252,8 +251,8 @@ class JdbcOutputFormatTest extends JdbcDataTestBase {
                                                     JdbcExecutionOptions.builder().build())
                                             .setRowDataTypeInfo(rowDataTypeInfo)
                                             .build();
-                            setRuntimeContext(outputFormat, true);
-                            outputFormat.open(0, 1);
+
+                            outputFormat.open(getExecutionConfig(true));
 
                             TestEntry entry = TEST_DATA[0];
                             RowData row =
@@ -297,11 +296,9 @@ class JdbcOutputFormatTest extends JdbcDataTestBase {
                         .setJdbcExecutionOptions(JdbcExecutionOptions.builder().build())
                         .setRowDataTypeInfo(rowDataTypeInfo)
                         .build();
-        setRuntimeContext(outputFormat, true);
-        outputFormat.open(0, 1);
 
-        setRuntimeContext(outputFormat, true);
-        outputFormat.open(0, 1);
+        outputFormat.open(getExecutionConfig(true));
+        outputFormat.open(getExecutionConfig(true));
 
         for (TestEntry entry : TEST_DATA) {
             outputFormat.writeRecord(
@@ -352,12 +349,12 @@ class JdbcOutputFormatTest extends JdbcDataTestBase {
                         .setJdbcExecutionOptions(executionOptions)
                         .setRowDataTypeInfo(rowDataTypeInfo)
                         .build();
-        setRuntimeContext(outputFormat, true);
-        outputFormat.open(0, 1);
+
+        outputFormat.open(getExecutionConfig(true));
 
         try (Connection dbConn = DriverManager.getConnection(DERBY_EBOOKSHOP_DB.getUrl());
                 PreparedStatement statement = dbConn.prepareStatement(SELECT_ALL_NEWBOOKS_2)) {
-            outputFormat.open(0, 1);
+            outputFormat.open(getExecutionConfig(false));
             for (int i = 0; i < 2; ++i) {
                 outputFormat.writeRecord(
                         buildGenericData(
@@ -422,11 +419,10 @@ class JdbcOutputFormatTest extends JdbcDataTestBase {
                         .setJdbcExecutionOptions(executionOptions)
                         .setRowDataTypeInfo(rowDataTypeInfo)
                         .build();
-        setRuntimeContext(outputFormat, true);
 
         try (Connection dbConn = DriverManager.getConnection(DERBY_EBOOKSHOP_DB.getUrl());
                 PreparedStatement statement = dbConn.prepareStatement(SELECT_ALL_NEWBOOKS_2)) {
-            outputFormat.open(0, 1);
+            outputFormat.open(getExecutionConfig(true));
             for (int i = 0; i < 2; ++i) {
                 outputFormat.writeRecord(
                         buildGenericData(
@@ -467,8 +463,8 @@ class JdbcOutputFormatTest extends JdbcDataTestBase {
                         .setJdbcExecutionOptions(JdbcExecutionOptions.builder().build())
                         .setRowDataTypeInfo(rowDataTypeInfo)
                         .build();
-        setRuntimeContext(outputFormat, true);
-        outputFormat.open(0, 1);
+
+        outputFormat.open(getExecutionConfig(true));
 
         // write records
         for (int i = 0; i < 3; i++) {


### PR DESCRIPTION
To be able to use the JdbcOutputFormat on the new sink based on SinkV2, we need to change the JdbcOutputFormat to be free of RuntimeContext

the JdbcOutputFormat need to know if ObjectReuse is active.


Some notes:
- should we change the name of JdbcOutputFormat, as it is no longer extending OutputFormat?
- the JdbcOutputFormat.Builder is not used internally, should we remove the builder or force the creation of JdbcOutputFormat only in the builder?