### PR TITLE
[FLINK-29750][Connector/JDBC]Support to write data to jdbc when disable flush-interval and max-rows

### DIFF
--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/JdbcOutputFormat.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/JdbcOutputFormat.java
@@ -142,7 +142,7 @@ public class JdbcOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatchStatementExe
             throw new IOException("unable to open JDBC writer", e);
         }
         jdbcStatementExecutor = createAndOpenStatementExecutor(statementExecutorFactory);
-        if (executionOptions.getBatchIntervalMs() != 0 && executionOptions.getBatchSize() != 1) {
+        if (executionOptions.getBatchIntervalMs() != 0 && executionOptions.getBatchSize() > 1) {
             this.scheduler =
                     Executors.newScheduledThreadPool(
                             1, new ExecutorThreadFactory("jdbc-upsert-output-format"));
@@ -190,7 +190,7 @@ public class JdbcOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatchStatementExe
             In recordCopy = copyIfNecessary(record);
             addToBatch(record, jdbcRecordExtractor.apply(recordCopy));
             batchCount++;
-            if (executionOptions.getBatchSize() > 0
+            if (executionOptions.getBatchSize() >= 0
                     && batchCount >= executionOptions.getBatchSize()) {
                 flush();
             }

--- a/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcOutputFormatTest.java
+++ b/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcOutputFormatTest.java
@@ -437,7 +437,7 @@ class JdbcOutputFormatTest extends JdbcDataTestBase {
                                 TEST_DATA[i].qty));
             }
             try (ResultSet resultSet = statement.executeQuery()) {
-                assertThat(resultSet.next()).isFalse();
+                assertThat(resultSet.next()).isTrue();
             }
         } finally {
             outputFormat.close();


### PR DESCRIPTION
## What is the purpose of the change




sink.buffer-flush.interval | The flush interval mills, over this time, asynchronous threads will flush data. Can be set to '0' to disable it. Note, 'sink.buffer-flush.max-rows' can be set to '0' with the flush interval set allowing for complete async processing of buffered actions.
-- | --
sink.buffer-flush.max-rows | The max size of buffered records before flush. Can be set to zero to disable it.


`Asynchronous thread flush` is disabled&nbsp; when set `sink.buffer-flush.interval` = 0,&nbsp; then disable `sink.buffer-flush.max-rows`, which causes the data is not written out.

The data are not written when disable `flush.interval` and `max-rows`. I think it should write out when the data arrive.


![image](https://user-images.githubusercontent.com/18002496/160043534-ff106f8e-d37a-4020-b598-2bfe639a50c8.png)

