### PR TITLE
[FLINK-30963][ci] Streamline binary URL configuration

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -26,5 +26,3 @@ jobs:
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
       flink_version: 1.16.1
-      flink_url: https://dist.apache.org/repos/dist/release/flink/flink-1.16.1/flink-1.16.1-bin-scala_2.12.tgz
-      cache_flink_binary: true

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -29,5 +29,3 @@ jobs:
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}
-      flink_url: https://s3.amazonaws.com/flink-nightly/flink-${{ matrix.flink }}-bin-scala_2.12.tgz
-      cache_flink_binary: false


### PR DESCRIPTION
The ci_utils workflow can now automatically infer the download URL and caching behavior. This implicitly switches stable binary downloads to archive.apache.org. This link will never expire; while the download speed is worse it shouldn't be a problem due to caching.

https://github.com/zentol/flink-connector-jdbc/actions/runs/4123496195/jobs/7121586447