### PR TITLE
[FLINK-31332] Limit the use of ExecutionConfig on JdbcOutputFormat

### DIFF
--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/JdbcRowOutputFormat.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/JdbcRowOutputFormat.java
@@ -19,7 +19,6 @@
 package org.apache.flink.connector.jdbc;
 
 import org.apache.flink.annotation.Experimental;
-import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.connector.jdbc.internal.JdbcOutputFormat;
 import org.apache.flink.connector.jdbc.internal.connection.JdbcConnectionProvider;
 import org.apache.flink.connector.jdbc.internal.connection.SimpleJdbcConnectionProvider;
@@ -28,8 +27,6 @@ import org.apache.flink.types.Row;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.function.Function;
 
 import static org.apache.flink.connector.jdbc.utils.JdbcUtils.setRecordToStatement;
 
@@ -53,18 +50,13 @@ public class JdbcRowOutputFormat
         super(
                 connectionProvider,
                 new JdbcExecutionOptions.Builder().withBatchSize(batchSize).build(),
-                ctx -> createRowExecutor(sql, typesArray, ctx),
-                JdbcOutputFormat.RecordExtractor.identity());
+                () -> createRowExecutor(sql, typesArray));
     }
 
-    private static JdbcBatchStatementExecutor<Row> createRowExecutor(
-            String sql, int[] typesArray, RuntimeContext ctx) {
+    private static JdbcBatchStatementExecutor<Row> createRowExecutor(String sql, int[] typesArray) {
         JdbcStatementBuilder<Row> statementBuilder =
                 (st, record) -> setRecordToStatement(st, typesArray, record);
-        return JdbcBatchStatementExecutor.simple(
-                sql,
-                statementBuilder,
-                ctx.getExecutionConfig().isObjectReuseEnabled() ? Row::copy : Function.identity());
+        return JdbcBatchStatementExecutor.simple(sql, statementBuilder);
     }
 
     public static JdbcOutputFormatBuilder buildJdbcOutputFormat() {

--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/JdbcSink.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/JdbcSink.java
@@ -29,8 +29,6 @@ import org.apache.flink.util.function.SerializableSupplier;
 
 import javax.sql.XADataSource;
 
-import java.util.function.Function;
-
 /** Facade to create JDBC {@link SinkFunction sinks}. */
 @PublicEvolving
 public class JdbcSink {
@@ -71,10 +69,7 @@ public class JdbcSink {
                 new JdbcOutputFormat<>(
                         new SimpleJdbcConnectionProvider(connectionOptions),
                         executionOptions,
-                        context ->
-                                JdbcBatchStatementExecutor.simple(
-                                        sql, statementBuilder, Function.identity()),
-                        JdbcOutputFormat.RecordExtractor.identity()));
+                        () -> JdbcBatchStatementExecutor.simple(sql, statementBuilder)));
     }
 
     /**

--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/GenericJdbcSinkFunction.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/GenericJdbcSinkFunction.java
@@ -20,7 +20,6 @@ package org.apache.flink.connector.jdbc.internal;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.InputTypeConfigurable;
 import org.apache.flink.configuration.Configuration;
@@ -39,6 +38,7 @@ import java.io.IOException;
 public class GenericJdbcSinkFunction<T> extends RichSinkFunction<T>
         implements CheckpointedFunction, InputTypeConfigurable {
     private final JdbcOutputFormat<T, ?, ?> outputFormat;
+    private JdbcOutputSerializer<T> serializer;
 
     public GenericJdbcSinkFunction(@Nonnull JdbcOutputFormat<T, ?, ?> outputFormat) {
         this.outputFormat = Preconditions.checkNotNull(outputFormat);
@@ -47,9 +47,9 @@ public class GenericJdbcSinkFunction<T> extends RichSinkFunction<T>
     @Override
     public void open(Configuration parameters) throws Exception {
         super.open(parameters);
-        RuntimeContext ctx = getRuntimeContext();
-        outputFormat.setRuntimeContext(ctx);
-        outputFormat.open(ctx.getIndexOfThisSubtask(), ctx.getNumberOfParallelSubtasks());
+        // Recheck if execution config change
+        serializer.configure(getRuntimeContext().getExecutionConfig());
+        outputFormat.open(serializer);
     }
 
     @Override
@@ -71,7 +71,9 @@ public class GenericJdbcSinkFunction<T> extends RichSinkFunction<T>
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public void setInputType(TypeInformation<?> type, ExecutionConfig executionConfig) {
-        outputFormat.setInputType(type, executionConfig);
+        this.serializer =
+                JdbcOutputSerializer.of((TypeInformation<T>) type).configure(executionConfig);
     }
 }

--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/JdbcOutputFormat.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/JdbcOutputFormat.java
@@ -20,76 +20,36 @@ package org.apache.flink.connector.jdbc.internal;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.functions.RuntimeContext;
-import org.apache.flink.api.common.io.RichOutputFormat;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.api.java.typeutils.InputTypeConfigurable;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.jdbc.JdbcExecutionOptions;
-import org.apache.flink.connector.jdbc.JdbcStatementBuilder;
 import org.apache.flink.connector.jdbc.internal.connection.JdbcConnectionProvider;
-import org.apache.flink.connector.jdbc.internal.connection.SimpleJdbcConnectionProvider;
 import org.apache.flink.connector.jdbc.internal.executor.JdbcBatchStatementExecutor;
-import org.apache.flink.connector.jdbc.internal.options.JdbcConnectorOptions;
-import org.apache.flink.connector.jdbc.internal.options.JdbcDmlOptions;
-import org.apache.flink.connector.jdbc.statement.FieldNamedPreparedStatementImpl;
-import org.apache.flink.connector.jdbc.utils.JdbcUtils;
-import org.apache.flink.types.Row;
-import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.concurrent.ExecutorThreadFactory;
-import org.apache.flink.util.function.SerializableFunction;
+import org.apache.flink.util.function.SerializableSupplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 import java.io.Flushable;
 import java.io.IOException;
 import java.io.Serializable;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.HashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
-import static org.apache.flink.connector.jdbc.utils.JdbcUtils.setRecordToStatement;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** A JDBC outputFormat that supports batching records before writing records to database. */
 @Internal
 public class JdbcOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatchStatementExecutor<JdbcIn>>
-        extends RichOutputFormat<In> implements Flushable, InputTypeConfigurable {
+        implements Flushable, AutoCloseable, Serializable {
 
     protected final JdbcConnectionProvider connectionProvider;
-    @Nullable private TypeSerializer<In> serializer;
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public void setInputType(TypeInformation<?> type, ExecutionConfig executionConfig) {
-        if (executionConfig.isObjectReuseEnabled()) {
-            this.serializer = (TypeSerializer<In>) type.createSerializer(executionConfig);
-        }
-    }
-
-    /**
-     * An interface to extract a value from given argument.
-     *
-     * @param <F> The type of given argument
-     * @param <T> The type of the return value
-     */
-    public interface RecordExtractor<F, T> extends Function<F, T>, Serializable {
-        static <T> RecordExtractor<T, T> identity() {
-            return x -> x;
-        }
-    }
 
     /**
      * A factory for creating {@link JdbcBatchStatementExecutor} instance.
@@ -97,7 +57,7 @@ public class JdbcOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatchStatementExe
      * @param <T> The type of instance.
      */
     public interface StatementExecutorFactory<T extends JdbcBatchStatementExecutor<?>>
-            extends SerializableFunction<RuntimeContext, T> {}
+            extends SerializableSupplier<T> {}
 
     private static final long serialVersionUID = 1L;
 
@@ -105,8 +65,13 @@ public class JdbcOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatchStatementExe
 
     private final JdbcExecutionOptions executionOptions;
     private final StatementExecutorFactory<JdbcExec> statementExecutorFactory;
-    private final RecordExtractor<In, JdbcIn> jdbcRecordExtractor;
 
+    @SuppressWarnings("unchecked")
+    protected Function<In, JdbcIn> getExtractor() {
+        return in -> (JdbcIn) in;
+    }
+
+    private transient JdbcOutputSerializer<In> serializer;
     private transient JdbcExec jdbcStatementExecutor;
     private transient int batchCount = 0;
     private transient volatile boolean closed = false;
@@ -118,29 +83,21 @@ public class JdbcOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatchStatementExe
     public JdbcOutputFormat(
             @Nonnull JdbcConnectionProvider connectionProvider,
             @Nonnull JdbcExecutionOptions executionOptions,
-            @Nonnull StatementExecutorFactory<JdbcExec> statementExecutorFactory,
-            @Nonnull RecordExtractor<In, JdbcIn> recordExtractor) {
+            @Nonnull StatementExecutorFactory<JdbcExec> statementExecutorFactory) {
         this.connectionProvider = checkNotNull(connectionProvider);
         this.executionOptions = checkNotNull(executionOptions);
         this.statementExecutorFactory = checkNotNull(statementExecutorFactory);
-        this.jdbcRecordExtractor = checkNotNull(recordExtractor);
     }
 
-    @Override
-    public void configure(Configuration parameters) {}
-
-    /**
-     * Connects to the target database and initializes the prepared statement.
-     *
-     * @param taskNumber The number of the parallel instance.
-     */
-    @Override
-    public void open(int taskNumber, int numTasks) throws IOException {
+    /** Connects to the target database and initializes the prepared statement. */
+    public void open(@Nonnull JdbcOutputSerializer<In> serializer) throws IOException {
+        this.serializer = checkNotNull(serializer, "Serializer must be defined");
         try {
             connectionProvider.getOrEstablishConnection();
         } catch (Exception e) {
             throw new IOException("unable to open JDBC writer", e);
         }
+
         jdbcStatementExecutor = createAndOpenStatementExecutor(statementExecutorFactory);
         if (executionOptions.getBatchIntervalMs() != 0 && executionOptions.getBatchSize() != 1) {
             this.scheduler =
@@ -167,7 +124,7 @@ public class JdbcOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatchStatementExe
 
     private JdbcExec createAndOpenStatementExecutor(
             StatementExecutorFactory<JdbcExec> statementExecutorFactory) throws IOException {
-        JdbcExec exec = statementExecutorFactory.apply(getRuntimeContext());
+        JdbcExec exec = statementExecutorFactory.get();
         try {
             exec.prepareStatements(connectionProvider.getConnection());
         } catch (SQLException e) {
@@ -182,13 +139,12 @@ public class JdbcOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatchStatementExe
         }
     }
 
-    @Override
     public final synchronized void writeRecord(In record) throws IOException {
         checkFlushException();
 
         try {
             In recordCopy = copyIfNecessary(record);
-            addToBatch(record, jdbcRecordExtractor.apply(recordCopy));
+            addToBatch(record, getExtractor().apply(recordCopy));
             batchCount++;
             if (executionOptions.getBatchSize() > 0
                     && batchCount >= executionOptions.getBatchSize()) {
@@ -200,7 +156,7 @@ public class JdbcOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatchStatementExe
     }
 
     private In copyIfNecessary(In record) {
-        return serializer == null ? record : serializer.copy(record);
+        return this.serializer.serialize(record);
     }
 
     protected void addToBatch(In original, JdbcIn extracted) throws SQLException {
@@ -276,126 +232,6 @@ public class JdbcOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatchStatementExe
         }
         connectionProvider.closeConnection();
         checkFlushException();
-    }
-
-    public static Builder builder() {
-        return new Builder();
-    }
-
-    /** Builder for a {@link JdbcOutputFormat}. */
-    public static class Builder {
-        private JdbcConnectorOptions options;
-        private String[] fieldNames;
-        private String[] keyFields;
-        private int[] fieldTypes;
-        private JdbcExecutionOptions.Builder executionOptionsBuilder =
-                JdbcExecutionOptions.builder();
-
-        /** required, jdbc options. */
-        public Builder setOptions(JdbcConnectorOptions options) {
-            this.options = options;
-            return this;
-        }
-
-        /** required, field names of this jdbc sink. */
-        public Builder setFieldNames(String[] fieldNames) {
-            this.fieldNames = fieldNames;
-            return this;
-        }
-
-        /** required, upsert unique keys. */
-        public Builder setKeyFields(String[] keyFields) {
-            this.keyFields = keyFields;
-            return this;
-        }
-
-        /** required, field types of this jdbc sink. */
-        public Builder setFieldTypes(int[] fieldTypes) {
-            this.fieldTypes = fieldTypes;
-            return this;
-        }
-
-        /**
-         * optional, flush max size (includes all append, upsert and delete records), over this
-         * number of records, will flush data.
-         */
-        public Builder setFlushMaxSize(int flushMaxSize) {
-            executionOptionsBuilder.withBatchSize(flushMaxSize);
-            return this;
-        }
-
-        /** optional, flush interval mills, over this time, asynchronous threads will flush data. */
-        public Builder setFlushIntervalMills(long flushIntervalMills) {
-            executionOptionsBuilder.withBatchIntervalMs(flushIntervalMills);
-            return this;
-        }
-
-        /** optional, max retry times for jdbc connector. */
-        public Builder setMaxRetryTimes(int maxRetryTimes) {
-            executionOptionsBuilder.withMaxRetries(maxRetryTimes);
-            return this;
-        }
-
-        /**
-         * Finalizes the configuration and checks validity.
-         *
-         * @return Configured JdbcUpsertOutputFormat
-         */
-        public JdbcOutputFormat<Tuple2<Boolean, Row>, Row, JdbcBatchStatementExecutor<Row>>
-                build() {
-            checkNotNull(options, "No options supplied.");
-            checkNotNull(fieldNames, "No fieldNames supplied.");
-            JdbcDmlOptions dml =
-                    JdbcDmlOptions.builder()
-                            .withTableName(options.getTableName())
-                            .withDialect(options.getDialect())
-                            .withFieldNames(fieldNames)
-                            .withKeyFields(keyFields)
-                            .withFieldTypes(fieldTypes)
-                            .build();
-            if (dml.getKeyFields().isPresent() && dml.getKeyFields().get().length > 0) {
-                return new TableJdbcUpsertOutputFormat(
-                        new SimpleJdbcConnectionProvider(options),
-                        dml,
-                        executionOptionsBuilder.build());
-            } else {
-                // warn: don't close over builder fields
-                String sql =
-                        FieldNamedPreparedStatementImpl.parseNamedStatement(
-                                options.getDialect()
-                                        .getInsertIntoStatement(
-                                                dml.getTableName(), dml.getFieldNames()),
-                                new HashMap<>());
-                return new JdbcOutputFormat<>(
-                        new SimpleJdbcConnectionProvider(options),
-                        executionOptionsBuilder.build(),
-                        ctx ->
-                                createSimpleRowExecutor(
-                                        sql,
-                                        dml.getFieldTypes(),
-                                        ctx.getExecutionConfig().isObjectReuseEnabled()),
-                        tuple2 -> {
-                            Preconditions.checkArgument(tuple2.f0);
-                            return tuple2.f1;
-                        });
-            }
-        }
-    }
-
-    static JdbcBatchStatementExecutor<Row> createSimpleRowExecutor(
-            String sql, int[] fieldTypes, boolean objectReuse) {
-        return JdbcBatchStatementExecutor.simple(
-                sql,
-                createRowJdbcStatementBuilder(fieldTypes),
-                objectReuse ? Row::copy : Function.identity());
-    }
-
-    /**
-     * Creates a {@link JdbcStatementBuilder} for {@link Row} using the provided SQL types array.
-     * Uses {@link JdbcUtils#setRecordToStatement}
-     */
-    static JdbcStatementBuilder<Row> createRowJdbcStatementBuilder(int[] types) {
-        return (st, record) -> setRecordToStatement(st, types, record);
     }
 
     public void updateExecutor(boolean reconnect) throws SQLException, ClassNotFoundException {

--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/JdbcOutputSerializer.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/JdbcOutputSerializer.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.internal;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+import java.io.Serializable;
+
+/** A Serializer that have in account the actual configuration. */
+@Internal
+public class JdbcOutputSerializer<T> implements Serializable {
+
+    private final TypeInformation<T> typeInformation;
+    private TypeSerializer<T> typeSerializer;
+
+    private JdbcOutputSerializer(TypeInformation<T> typeInformation) {
+        this.typeInformation = typeInformation;
+    }
+
+    public static <S> JdbcOutputSerializer<S> of(TypeInformation<S> typeInformation) {
+        return new JdbcOutputSerializer<>(typeInformation);
+    }
+
+    public JdbcOutputSerializer<T> configure(ExecutionConfig executionConfig) {
+        if (executionConfig != null && executionConfig.isObjectReuseEnabled()) {
+            this.typeSerializer = typeInformation.createSerializer(executionConfig);
+        }
+        return this;
+    }
+
+    public T serialize(T record) {
+        return this.typeSerializer == null ? record : typeSerializer.copy(record);
+    }
+}

--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/RowJdbcOutputFormat.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/RowJdbcOutputFormat.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.internal;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.jdbc.JdbcExecutionOptions;
+import org.apache.flink.connector.jdbc.JdbcStatementBuilder;
+import org.apache.flink.connector.jdbc.internal.connection.JdbcConnectionProvider;
+import org.apache.flink.connector.jdbc.internal.connection.SimpleJdbcConnectionProvider;
+import org.apache.flink.connector.jdbc.internal.executor.JdbcBatchStatementExecutor;
+import org.apache.flink.connector.jdbc.internal.options.JdbcConnectorOptions;
+import org.apache.flink.connector.jdbc.internal.options.JdbcDmlOptions;
+import org.apache.flink.connector.jdbc.statement.FieldNamedPreparedStatementImpl;
+import org.apache.flink.connector.jdbc.utils.JdbcUtils;
+import org.apache.flink.types.Row;
+
+import javax.annotation.Nonnull;
+
+import java.util.HashMap;
+
+import static org.apache.flink.connector.jdbc.utils.JdbcUtils.setRecordToStatement;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** A JDBC Row outputFormat that supports batching records before writing records to database. */
+@Internal
+public class RowJdbcOutputFormat<In>
+        extends JdbcOutputFormat<In, Row, JdbcBatchStatementExecutor<Row>> {
+
+    public RowJdbcOutputFormat(
+            @Nonnull JdbcConnectionProvider connectionProvider,
+            @Nonnull JdbcExecutionOptions executionOptions,
+            @Nonnull
+                    StatementExecutorFactory<JdbcBatchStatementExecutor<Row>>
+                            statementExecutorFactory) {
+        super(connectionProvider, executionOptions, statementExecutorFactory);
+    }
+
+    static JdbcBatchStatementExecutor<Row> createSimpleRowExecutor(String sql, int[] fieldTypes) {
+        return JdbcBatchStatementExecutor.simple(sql, createRowJdbcStatementBuilder(fieldTypes));
+    }
+
+    /**
+     * Creates a {@link JdbcStatementBuilder} for {@link Row} using the provided SQL types array.
+     * Uses {@link JdbcUtils#setRecordToStatement}
+     */
+    static JdbcStatementBuilder<Row> createRowJdbcStatementBuilder(int[] types) {
+        return (st, record) -> setRecordToStatement(st, types, record);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Builder for a {@link JdbcOutputFormat} using Row. */
+    public static class Builder {
+        private JdbcConnectorOptions options;
+
+        private JdbcDmlOptions.JdbcDmlOptionsBuilder dmlOptionsBuilder = JdbcDmlOptions.builder();
+        private JdbcExecutionOptions.Builder executionOptionsBuilder =
+                JdbcExecutionOptions.builder();
+
+        /** required, jdbc options. */
+        public Builder setOptions(JdbcConnectorOptions options) {
+            this.options = options;
+            this.dmlOptionsBuilder
+                    .withTableName(options.getTableName())
+                    .withDialect(options.getDialect());
+            return this;
+        }
+
+        /** required, field names of this jdbc sink. */
+        public Builder setFieldNames(String[] fieldNames) {
+            this.dmlOptionsBuilder.withFieldNames(fieldNames);
+            return this;
+        }
+
+        /** required, upsert unique keys. */
+        public Builder setKeyFields(String[] keyFields) {
+            this.dmlOptionsBuilder.withKeyFields(keyFields);
+            return this;
+        }
+
+        /** required, field types of this jdbc sink. */
+        public Builder setFieldTypes(int[] fieldTypes) {
+            this.dmlOptionsBuilder.withFieldTypes(fieldTypes);
+            return this;
+        }
+
+        /**
+         * optional, flush max size (includes all append, upsert and delete records), over this
+         * number of records, will flush data.
+         */
+        public Builder setFlushMaxSize(int flushMaxSize) {
+            executionOptionsBuilder.withBatchSize(flushMaxSize);
+            return this;
+        }
+
+        /** optional, flush interval mills, over this time, asynchronous threads will flush data. */
+        public Builder setFlushIntervalMills(long flushIntervalMills) {
+            executionOptionsBuilder.withBatchIntervalMs(flushIntervalMills);
+            return this;
+        }
+
+        /** optional, max retry times for jdbc connector. */
+        public Builder setMaxRetryTimes(int maxRetryTimes) {
+            executionOptionsBuilder.withMaxRetries(maxRetryTimes);
+            return this;
+        }
+
+        /**
+         * Finalizes the configuration and checks validity.
+         *
+         * @return Configured JdbcUpsertOutputFormat
+         */
+        public JdbcOutputFormat<Row, Row, JdbcBatchStatementExecutor<Row>> build() {
+            checkNotNull(options, "No options supplied.");
+
+            JdbcDmlOptions dml = this.dmlOptionsBuilder.build();
+            // warn: don't close over builder fields
+            String sql =
+                    FieldNamedPreparedStatementImpl.parseNamedStatement(
+                            options.getDialect()
+                                    .getInsertIntoStatement(
+                                            dml.getTableName(), dml.getFieldNames()),
+                            new HashMap<>());
+            return new RowJdbcOutputFormat<>(
+                    new SimpleJdbcConnectionProvider(options),
+                    executionOptionsBuilder.build(),
+                    () -> createSimpleRowExecutor(sql, dml.getFieldTypes()));
+        }
+    }
+}

--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/TableJdbcUpsertOutputFormat.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/TableJdbcUpsertOutputFormat.java
@@ -18,8 +18,6 @@
 package org.apache.flink.connector.jdbc.internal;
 
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.api.common.functions.RuntimeContext;
-import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.connector.jdbc.JdbcExecutionOptions;
 import org.apache.flink.connector.jdbc.internal.connection.JdbcConnectionProvider;
 import org.apache.flink.connector.jdbc.internal.executor.InsertOrUpdateJdbcExecutor;
@@ -27,9 +25,12 @@ import org.apache.flink.connector.jdbc.internal.executor.JdbcBatchStatementExecu
 import org.apache.flink.connector.jdbc.internal.options.JdbcDmlOptions;
 import org.apache.flink.connector.jdbc.statement.FieldNamedPreparedStatementImpl;
 import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
 
 import java.io.IOException;
 import java.sql.SQLException;
@@ -41,8 +42,7 @@ import static org.apache.flink.connector.jdbc.utils.JdbcUtils.getPrimaryKey;
 import static org.apache.flink.connector.jdbc.utils.JdbcUtils.setRecordToStatement;
 import static org.apache.flink.util.Preconditions.checkArgument;
 
-class TableJdbcUpsertOutputFormat
-        extends JdbcOutputFormat<Tuple2<Boolean, Row>, Row, JdbcBatchStatementExecutor<Row>> {
+class TableJdbcUpsertOutputFormat extends RowJdbcOutputFormat<Row> {
     private static final Logger LOG = LoggerFactory.getLogger(TableJdbcUpsertOutputFormat.class);
 
     private JdbcBatchStatementExecutor<Row> deleteExecutor;
@@ -56,8 +56,8 @@ class TableJdbcUpsertOutputFormat
         this(
                 connectionProvider,
                 batchOptions,
-                ctx -> createUpsertRowExecutor(dmlOptions, ctx),
-                ctx -> createDeleteExecutor(dmlOptions, ctx));
+                () -> createUpsertRowExecutor(dmlOptions),
+                () -> createDeleteExecutor(dmlOptions));
     }
 
     @VisibleForTesting
@@ -67,14 +67,14 @@ class TableJdbcUpsertOutputFormat
             StatementExecutorFactory<JdbcBatchStatementExecutor<Row>> statementExecutorFactory,
             StatementExecutorFactory<JdbcBatchStatementExecutor<Row>>
                     deleteStatementExecutorFactory) {
-        super(connectionProvider, batchOptions, statementExecutorFactory, tuple2 -> tuple2.f1);
+        super(connectionProvider, batchOptions, statementExecutorFactory);
         this.deleteStatementExecutorFactory = deleteStatementExecutorFactory;
     }
 
     @Override
-    public void open(int taskNumber, int numTasks) throws IOException {
-        super.open(taskNumber, numTasks);
-        deleteExecutor = deleteStatementExecutorFactory.apply(getRuntimeContext());
+    public void open(@Nonnull JdbcOutputSerializer<Row> serializer) throws IOException {
+        super.open(serializer);
+        deleteExecutor = deleteStatementExecutorFactory.get();
         try {
             deleteExecutor.prepareStatements(connectionProvider.getConnection());
         } catch (SQLException e) {
@@ -82,8 +82,7 @@ class TableJdbcUpsertOutputFormat
         }
     }
 
-    private static JdbcBatchStatementExecutor<Row> createDeleteExecutor(
-            JdbcDmlOptions dmlOptions, RuntimeContext ctx) {
+    private static JdbcBatchStatementExecutor<Row> createDeleteExecutor(JdbcDmlOptions dmlOptions) {
         int[] pkFields =
                 Arrays.stream(dmlOptions.getFieldNames())
                         .mapToInt(Arrays.asList(dmlOptions.getFieldNames())::indexOf)
@@ -103,8 +102,8 @@ class TableJdbcUpsertOutputFormat
     }
 
     @Override
-    protected void addToBatch(Tuple2<Boolean, Row> original, Row extracted) throws SQLException {
-        if (original.f0) {
+    protected void addToBatch(Row original, Row extracted) throws SQLException {
+        if (original.getKind() != RowKind.DELETE) {
             super.addToBatch(original, extracted);
         } else {
             deleteExecutor.addToBatch(extracted);
@@ -149,8 +148,7 @@ class TableJdbcUpsertOutputFormat
                                 st, pkTypes, createRowKeyExtractor(pkFields).apply(record)));
     }
 
-    private static JdbcBatchStatementExecutor<Row> createUpsertRowExecutor(
-            JdbcDmlOptions opt, RuntimeContext ctx) {
+    private static JdbcBatchStatementExecutor<Row> createUpsertRowExecutor(JdbcDmlOptions opt) {
         checkArgument(opt.getKeyFields().isPresent());
 
         int[] pkFields =
@@ -165,12 +163,7 @@ class TableJdbcUpsertOutputFormat
         return opt.getDialect()
                 .getUpsertStatement(
                         opt.getTableName(), opt.getFieldNames(), opt.getKeyFields().get())
-                .map(
-                        sql ->
-                                createSimpleRowExecutor(
-                                        parseNamedStatement(sql),
-                                        opt.getFieldTypes(),
-                                        ctx.getExecutionConfig().isObjectReuseEnabled()))
+                .map(sql -> createSimpleRowExecutor(parseNamedStatement(sql), opt.getFieldTypes()))
                 .orElseGet(
                         () ->
                                 new InsertOrUpdateJdbcExecutor<>(
@@ -194,9 +187,7 @@ class TableJdbcUpsertOutputFormat
                                         createRowJdbcStatementBuilder(opt.getFieldTypes()),
                                         createRowJdbcStatementBuilder(opt.getFieldTypes()),
                                         createRowKeyExtractor(pkFields),
-                                        ctx.getExecutionConfig().isObjectReuseEnabled()
-                                                ? Row::copy
-                                                : Function.identity()));
+                                        Function.identity()));
     }
 
     private static String parseNamedStatement(String statement) {

--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/executor/JdbcBatchStatementExecutor.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/executor/JdbcBatchStatementExecutor.java
@@ -45,8 +45,8 @@ public interface JdbcBatchStatementExecutor<T> {
         return new KeyedBatchStatementExecutor<>(sql, keyExtractor, statementBuilder);
     }
 
-    static <T, V> JdbcBatchStatementExecutor<T> simple(
-            String sql, JdbcStatementBuilder<V> paramSetter, Function<T, V> valueTransformer) {
-        return new SimpleBatchStatementExecutor<>(sql, paramSetter, valueTransformer);
+    static <T> JdbcBatchStatementExecutor<T> simple(
+            String sql, JdbcStatementBuilder<T> paramSetter) {
+        return new SimpleBatchStatementExecutor<>(sql, paramSetter);
     }
 }

--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/executor/SimpleBatchStatementExecutor.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/executor/SimpleBatchStatementExecutor.java
@@ -28,28 +28,24 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Function;
 
 /**
  * A {@link JdbcBatchStatementExecutor} that executes supplied statement for given the records
  * (without any pre-processing).
  */
-class SimpleBatchStatementExecutor<T, V> implements JdbcBatchStatementExecutor<T> {
+class SimpleBatchStatementExecutor<T> implements JdbcBatchStatementExecutor<T> {
 
     private static final Logger LOG = LoggerFactory.getLogger(SimpleBatchStatementExecutor.class);
 
     private final String sql;
-    private final JdbcStatementBuilder<V> parameterSetter;
-    private final Function<T, V> valueTransformer;
-    private final List<V> batch;
+    private final JdbcStatementBuilder<T> parameterSetter;
+    private final List<T> batch;
 
     private transient PreparedStatement st;
 
-    SimpleBatchStatementExecutor(
-            String sql, JdbcStatementBuilder<V> statementBuilder, Function<T, V> valueTransformer) {
+    SimpleBatchStatementExecutor(String sql, JdbcStatementBuilder<T> statementBuilder) {
         this.sql = sql;
         this.parameterSetter = statementBuilder;
-        this.valueTransformer = valueTransformer;
         this.batch = new ArrayList<>();
     }
 
@@ -60,13 +56,13 @@ class SimpleBatchStatementExecutor<T, V> implements JdbcBatchStatementExecutor<T
 
     @Override
     public void addToBatch(T record) {
-        batch.add(valueTransformer.apply(record));
+        batch.add(record);
     }
 
     @Override
     public void executeBatch() throws SQLException {
         if (!batch.isEmpty()) {
-            for (V r : batch) {
+            for (T r : batch) {
                 parameterSetter.accept(st, r);
                 st.addBatch();
             }

--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/executor/TableBufferReducedStatementExecutor.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/executor/TableBufferReducedStatementExecutor.java
@@ -38,19 +38,16 @@ public final class TableBufferReducedStatementExecutor
     private final JdbcBatchStatementExecutor<RowData> upsertExecutor;
     private final JdbcBatchStatementExecutor<RowData> deleteExecutor;
     private final Function<RowData, RowData> keyExtractor;
-    private final Function<RowData, RowData> valueTransform;
     // the mapping is [KEY, <+/-, VALUE>]
     private final Map<RowData, Tuple2<Boolean, RowData>> reduceBuffer = new HashMap<>();
 
     public TableBufferReducedStatementExecutor(
             JdbcBatchStatementExecutor<RowData> upsertExecutor,
             JdbcBatchStatementExecutor<RowData> deleteExecutor,
-            Function<RowData, RowData> keyExtractor,
-            Function<RowData, RowData> valueTransform) {
+            Function<RowData, RowData> keyExtractor) {
         this.upsertExecutor = upsertExecutor;
         this.deleteExecutor = deleteExecutor;
         this.keyExtractor = keyExtractor;
-        this.valueTransform = valueTransform;
     }
 
     @Override
@@ -63,8 +60,7 @@ public final class TableBufferReducedStatementExecutor
     public void addToBatch(RowData record) throws SQLException {
         RowData key = keyExtractor.apply(record);
         boolean flag = changeFlag(record.getRowKind());
-        RowData value = valueTransform.apply(record); // copy or not
-        reduceBuffer.put(key, Tuple2.of(flag, value));
+        reduceBuffer.put(key, Tuple2.of(flag, record));
     }
 
     /**

--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/executor/TableBufferedStatementExecutor.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/executor/TableBufferedStatementExecutor.java
@@ -25,7 +25,6 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Function;
 
 /**
  * Currently, this statement executor is only used for table/sql to buffer records, because the
@@ -35,14 +34,10 @@ import java.util.function.Function;
 public final class TableBufferedStatementExecutor implements JdbcBatchStatementExecutor<RowData> {
 
     private final JdbcBatchStatementExecutor<RowData> statementExecutor;
-    private final Function<RowData, RowData> valueTransform;
     private final List<RowData> buffer = new ArrayList<>();
 
-    public TableBufferedStatementExecutor(
-            JdbcBatchStatementExecutor<RowData> statementExecutor,
-            Function<RowData, RowData> valueTransform) {
+    public TableBufferedStatementExecutor(JdbcBatchStatementExecutor<RowData> statementExecutor) {
         this.statementExecutor = statementExecutor;
-        this.valueTransform = valueTransform;
     }
 
     @Override
@@ -52,8 +47,7 @@ public final class TableBufferedStatementExecutor implements JdbcBatchStatementE
 
     @Override
     public void addToBatch(RowData record) throws SQLException {
-        RowData value = valueTransform.apply(record); // copy or not
-        buffer.add(value);
+        buffer.add(record);
     }
 
     @Override

--- a/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/JdbcDataTestBase.java
+++ b/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/JdbcDataTestBase.java
@@ -17,22 +17,18 @@
 
 package org.apache.flink.connector.jdbc;
 
-import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.connector.jdbc.databases.DatabaseMetadata;
-import org.apache.flink.connector.jdbc.internal.JdbcOutputFormat;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.mockito.Mockito;
 
 import java.sql.SQLException;
 
 import static org.apache.flink.connector.jdbc.JdbcTestFixture.DERBY_EBOOKSHOP_DB;
-import static org.mockito.Mockito.doReturn;
 
 /**
  * Base class for JDBC test using data from {@link JdbcTestFixture}. It uses {@link
@@ -50,7 +46,15 @@ public abstract class JdbcDataTestBase extends JdbcTestBase {
     }
 
     public static Row toRow(JdbcTestFixture.TestEntry entry) {
-        Row row = new Row(5);
+        return toRow(RowKind.INSERT, entry);
+    }
+
+    public static Row toRowDelete(JdbcTestFixture.TestEntry entry) {
+        return toRow(RowKind.DELETE, entry);
+    }
+
+    private static Row toRow(RowKind rowKind, JdbcTestFixture.TestEntry entry) {
+        Row row = new Row(rowKind, 5);
         row.setField(0, entry.id);
         row.setField(1, entry.title);
         row.setField(2, entry.author);
@@ -70,13 +74,5 @@ public abstract class JdbcDataTestBase extends JdbcTestBase {
             }
         }
         return row;
-    }
-
-    public static void setRuntimeContext(JdbcOutputFormat format, Boolean reused) {
-        RuntimeContext context = Mockito.mock(RuntimeContext.class);
-        ExecutionConfig config = Mockito.mock(ExecutionConfig.class);
-        doReturn(config).when(context).getExecutionConfig();
-        doReturn(reused).when(config).isObjectReuseEnabled();
-        format.setRuntimeContext(context);
     }
 }

--- a/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/JdbcRowOutputFormatTest.java
+++ b/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/JdbcRowOutputFormatTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.connector.jdbc;
 
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.connector.jdbc.internal.JdbcOutputSerializer;
 import org.apache.flink.types.Row;
 
 import org.junit.jupiter.api.AfterEach;
@@ -78,7 +80,12 @@ class JdbcRowOutputFormatTest extends JdbcDataTestBase {
                             .setDBUrl(DERBY_EBOOKSHOP_DB.getJdbcUrl())
                             .setQuery(String.format(INSERT_TEMPLATE, INPUT_TABLE))
                             .finish();
-            jdbcOutputFormat.open(0, 1);
+
+            JdbcOutputSerializer<Row> serializer =
+                    JdbcOutputSerializer.of(TypeInformation.of(Row.class))
+                            .configure(getExecutionConfig(false));
+
+            jdbcOutputFormat.open(serializer);
         } catch (Exception e) {
             assertThat(findThrowable(e, IOException.class)).isPresent();
             assertThat(findThrowableWithMessage(e, expectedMsg)).isPresent();
@@ -95,7 +102,10 @@ class JdbcRowOutputFormatTest extends JdbcDataTestBase {
                         .setDBUrl("jdbc:der:iamanerror:mory:ebookshop")
                         .setQuery(String.format(INSERT_TEMPLATE, INPUT_TABLE))
                         .finish();
-        assertThatThrownBy(() -> jdbcOutputFormat.open(0, 1))
+        JdbcOutputSerializer<Row> serializer =
+                JdbcOutputSerializer.of(TypeInformation.of(Row.class))
+                        .configure(getExecutionConfig(false));
+        assertThatThrownBy(() -> jdbcOutputFormat.open(serializer))
                 .isInstanceOf(IOException.class)
                 .satisfies(anyCauseMatches(SQLException.class, expectedMsg));
     }
@@ -110,8 +120,10 @@ class JdbcRowOutputFormatTest extends JdbcDataTestBase {
                             .setDBUrl(DERBY_EBOOKSHOP_DB.getJdbcUrl())
                             .setQuery("iamnotsql")
                             .finish();
-            setRuntimeContext(jdbcOutputFormat, true);
-            jdbcOutputFormat.open(0, 1);
+            JdbcOutputSerializer<Row> serializer =
+                    JdbcOutputSerializer.of(TypeInformation.of(Row.class))
+                            .configure(getExecutionConfig(true));
+            jdbcOutputFormat.open(serializer);
         } catch (Exception e) {
             assertThat(findThrowable(e, IOException.class)).isPresent();
             assertThat(findThrowableWithMessage(e, expectedMsg)).isPresent();
@@ -143,8 +155,10 @@ class JdbcRowOutputFormatTest extends JdbcDataTestBase {
                             .setDBUrl(DERBY_EBOOKSHOP_DB.getJdbcUrl())
                             .setQuery(String.format(INSERT_TEMPLATE, INPUT_TABLE))
                             .finish();
-            setRuntimeContext(jdbcOutputFormat, true);
-            jdbcOutputFormat.open(0, 1);
+            JdbcOutputSerializer<Row> serializer =
+                    JdbcOutputSerializer.of(TypeInformation.of(Row.class))
+                            .configure(getExecutionConfig(true));
+            jdbcOutputFormat.open(serializer);
 
             Row row = new Row(5);
             row.setField(0, 4);
@@ -179,8 +193,10 @@ class JdbcRowOutputFormatTest extends JdbcDataTestBase {
                                         Types.INTEGER
                                     })
                             .finish();
-            setRuntimeContext(jdbcOutputFormat, true);
-            jdbcOutputFormat.open(0, 1);
+            JdbcOutputSerializer<Row> serializer =
+                    JdbcOutputSerializer.of(TypeInformation.of(Row.class))
+                            .configure(getExecutionConfig(true));
+            jdbcOutputFormat.open(serializer);
 
             TestEntry entry = TEST_DATA[0];
             Row row = new Row(5);
@@ -215,8 +231,10 @@ class JdbcRowOutputFormatTest extends JdbcDataTestBase {
                                         Types.INTEGER
                                     })
                             .finish();
-            setRuntimeContext(jdbcOutputFormat, true);
-            jdbcOutputFormat.open(0, 1);
+            JdbcOutputSerializer<Row> serializer =
+                    JdbcOutputSerializer.of(TypeInformation.of(Row.class))
+                            .configure(getExecutionConfig(true));
+            jdbcOutputFormat.open(serializer);
 
             TestEntry entry = TEST_DATA[0];
             Row row = new Row(5);
@@ -244,8 +262,10 @@ class JdbcRowOutputFormatTest extends JdbcDataTestBase {
                         .setDBUrl(DERBY_EBOOKSHOP_DB.getJdbcUrl())
                         .setQuery(String.format(INSERT_TEMPLATE, OUTPUT_TABLE))
                         .finish();
-        setRuntimeContext(jdbcOutputFormat, true);
-        jdbcOutputFormat.open(0, 1);
+        JdbcOutputSerializer<Row> serializer =
+                JdbcOutputSerializer.of(TypeInformation.of(Row.class))
+                        .configure(getExecutionConfig(true));
+        jdbcOutputFormat.open(serializer);
 
         for (TestEntry entry : TEST_DATA) {
             jdbcOutputFormat.writeRecord(toRow(entry));
@@ -279,10 +299,13 @@ class JdbcRowOutputFormatTest extends JdbcDataTestBase {
                         .setQuery(String.format(INSERT_TEMPLATE, OUTPUT_TABLE_2))
                         .setBatchSize(3)
                         .finish();
-        setRuntimeContext(jdbcOutputFormat, true);
+
+        JdbcOutputSerializer<Row> serializer =
+                JdbcOutputSerializer.of(TypeInformation.of(Row.class))
+                        .configure(getExecutionConfig(true));
         try (Connection dbConn = DriverManager.getConnection(DERBY_EBOOKSHOP_DB.getJdbcUrl());
                 PreparedStatement statement = dbConn.prepareStatement(SELECT_ALL_NEWBOOKS_2)) {
-            jdbcOutputFormat.open(0, 1);
+            jdbcOutputFormat.open(serializer);
             for (int i = 0; i < 2; ++i) {
                 jdbcOutputFormat.writeRecord(toRow(TEST_DATA[i]));
             }
@@ -318,8 +341,10 @@ class JdbcRowOutputFormatTest extends JdbcDataTestBase {
                         .setDBUrl(DERBY_EBOOKSHOP_DB.getJdbcUrl())
                         .setQuery(String.format(INSERT_TEMPLATE, OUTPUT_TABLE_3))
                         .finish();
-        setRuntimeContext(jdbcOutputFormat, true);
-        jdbcOutputFormat.open(0, 1);
+        JdbcOutputSerializer<Row> serializer =
+                JdbcOutputSerializer.of(TypeInformation.of(Row.class))
+                        .configure(getExecutionConfig(true));
+        jdbcOutputFormat.open(serializer);
 
         // write records
         for (int i = 0; i < 3; i++) {

--- a/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/JdbcTestBase.java
+++ b/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/JdbcTestBase.java
@@ -17,10 +17,15 @@
 
 package org.apache.flink.connector.jdbc;
 
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.connector.jdbc.databases.DatabaseTest;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mockito;
+
+import static org.mockito.Mockito.doReturn;
 
 /**
  * Base class for JDBC test using DDL from {@link JdbcTestFixture}. It uses create tables before
@@ -37,5 +42,18 @@ public abstract class JdbcTestBase implements DatabaseTest {
     public void after() throws Exception {
         JdbcTestFixture.cleanupData(getMetadata().getJdbcUrl());
         JdbcTestFixture.cleanUpDatabasesStatic(getMetadata());
+    }
+
+    public static RuntimeContext getRuntimeContext(Boolean reused) {
+        ExecutionConfig config = getExecutionConfig(reused);
+        RuntimeContext context = Mockito.mock(RuntimeContext.class);
+        doReturn(config).when(context).getExecutionConfig();
+        return context;
+    }
+
+    public static ExecutionConfig getExecutionConfig(Boolean reused) {
+        ExecutionConfig config = Mockito.mock(ExecutionConfig.class);
+        doReturn(reused).when(config).isObjectReuseEnabled();
+        return config;
     }
 }

--- a/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/dialect/oracle/OracleTableSinkITCase.java
+++ b/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/dialect/oracle/OracleTableSinkITCase.java
@@ -18,8 +18,10 @@
 
 package org.apache.flink.connector.jdbc.dialect.oracle;
 
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.tuple.Tuple4;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.jdbc.JdbcTestBase;
 import org.apache.flink.connector.jdbc.databases.oracle.OracleDatabase;
 import org.apache.flink.connector.jdbc.internal.GenericJdbcSinkFunction;
 import org.apache.flink.runtime.state.StateSnapshotContextSynchronousImpl;
@@ -445,6 +447,8 @@ class OracleTableSinkITCase extends AbstractTestBase implements OracleDatabase {
         GenericJdbcSinkFunction<RowData> sinkFunction =
                 (GenericJdbcSinkFunction<RowData>) sinkProvider.createSinkFunction();
         sinkFunction.setRuntimeContext(new MockStreamingRuntimeContext(true, 1, 0));
+        sinkFunction.setInputType(
+                TypeInformation.of(GenericRowData.class), JdbcTestBase.getExecutionConfig(false));
         sinkFunction.open(new Configuration());
         sinkFunction.invoke(GenericRowData.of(1L), SinkContextUtil.forTimestamp(1));
         sinkFunction.invoke(GenericRowData.of(2L), SinkContextUtil.forTimestamp(1));

--- a/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/dialect/sqlserver/SqlServerTableSinkITCase.java
+++ b/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/dialect/sqlserver/SqlServerTableSinkITCase.java
@@ -18,8 +18,10 @@
 
 package org.apache.flink.connector.jdbc.dialect.sqlserver;
 
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.tuple.Tuple4;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.jdbc.JdbcTestBase;
 import org.apache.flink.connector.jdbc.databases.sqlserver.SqlServerDatabase;
 import org.apache.flink.connector.jdbc.internal.GenericJdbcSinkFunction;
 import org.apache.flink.runtime.state.StateSnapshotContextSynchronousImpl;
@@ -477,6 +479,8 @@ class SqlServerTableSinkITCase extends AbstractTestBase implements SqlServerData
         GenericJdbcSinkFunction<RowData> sinkFunction =
                 (GenericJdbcSinkFunction<RowData>) sinkProvider.createSinkFunction();
         sinkFunction.setRuntimeContext(new MockStreamingRuntimeContext(true, 1, 0));
+        sinkFunction.setInputType(
+                TypeInformation.of(GenericRowData.class), JdbcTestBase.getExecutionConfig(false));
         sinkFunction.open(new Configuration());
         sinkFunction.invoke(GenericRowData.of(1L), SinkContextUtil.forTimestamp(1));
         sinkFunction.invoke(GenericRowData.of(2L), SinkContextUtil.forTimestamp(1));

--- a/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/internal/JdbcFullTest.java
+++ b/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/internal/JdbcFullTest.java
@@ -18,11 +18,11 @@
 
 package org.apache.flink.connector.jdbc.internal;
 
-import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.io.OutputFormat;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
-import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.jdbc.JdbcConnectionOptions;
 import org.apache.flink.connector.jdbc.JdbcDataTestBase;
 import org.apache.flink.connector.jdbc.JdbcExecutionOptions;
@@ -36,15 +36,15 @@ import org.apache.flink.types.Row;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
+import java.io.IOException;
+import java.io.Serializable;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Statement;
 import java.sql.Types;
-import java.util.function.Function;
 
 import static org.apache.flink.connector.jdbc.JdbcTestFixture.INSERT_TEMPLATE;
 import static org.apache.flink.connector.jdbc.JdbcTestFixture.OUTPUT_TABLE;
@@ -57,7 +57,6 @@ import static org.apache.flink.connector.jdbc.utils.JdbcUtils.setRecordToStateme
 import static org.apache.flink.util.ExceptionUtils.findThrowable;
 import static org.apache.flink.util.ExceptionUtils.findThrowableWithMessage;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.doReturn;
 
 /** Tests using both {@link JdbcInputFormat} and {@link JdbcOutputFormat}. */
 class JdbcFullTest extends JdbcDataTestBase {
@@ -76,8 +75,8 @@ class JdbcFullTest extends JdbcDataTestBase {
     void testEnrichedClassCastException() {
         String expectedMsg = "field index: 3, field value: 11.11.";
         try {
-            JdbcOutputFormat jdbcOutputFormat =
-                    JdbcOutputFormat.builder()
+            JdbcOutputFormat<Row, Row, ?> jdbcOutputFormat =
+                    RowJdbcOutputFormat.builder()
                             .setOptions(
                                     JdbcConnectorOptions.builder()
                                             .setDBUrl(getMetadata().getJdbcUrl())
@@ -94,15 +93,14 @@ class JdbcFullTest extends JdbcDataTestBase {
                                     })
                             .setKeyFields(null)
                             .build();
-            RuntimeContext context = Mockito.mock(RuntimeContext.class);
-            ExecutionConfig config = Mockito.mock(ExecutionConfig.class);
-            doReturn(config).when(context).getExecutionConfig();
-            doReturn(true).when(config).isObjectReuseEnabled();
-            jdbcOutputFormat.setRuntimeContext(context);
 
-            jdbcOutputFormat.open(1, 1);
+            JdbcOutputSerializer<Row> serializer =
+                    JdbcOutputSerializer.of(TypeInformation.of(Row.class))
+                            .configure(getExecutionConfig(true));
+            jdbcOutputFormat.open(serializer);
+
             Row inputRow = Row.of(1001, "Java public for dummies", "Tan Ah Teck", "11.11", 11);
-            jdbcOutputFormat.writeRecord(Tuple2.of(true, inputRow));
+            jdbcOutputFormat.writeRecord(inputRow);
             jdbcOutputFormat.close();
         } catch (Exception e) {
             assertThat(findThrowable(e, ClassCastException.class)).isPresent();
@@ -142,11 +140,11 @@ class JdbcFullTest extends JdbcDataTestBase {
                         .withDriverName(getMetadata().getDriverClass())
                         .build();
 
-        JdbcOutputFormat jdbcOutputFormat =
+        JdbcOutputFormat<Row, Row, ?> jdbcOutputFormat =
                 new JdbcOutputFormat<>(
                         new SimpleJdbcConnectionProvider(connectionOptions),
                         JdbcExecutionOptions.defaults(),
-                        ctx ->
+                        () ->
                                 createSimpleRowExecutor(
                                         String.format(INSERT_TEMPLATE, OUTPUT_TABLE),
                                         new int[] {
@@ -155,11 +153,8 @@ class JdbcFullTest extends JdbcDataTestBase {
                                             Types.VARCHAR,
                                             Types.DOUBLE,
                                             Types.INTEGER
-                                        },
-                                        ctx.getExecutionConfig().isObjectReuseEnabled()),
-                        JdbcOutputFormat.RecordExtractor.identity());
-
-        source.output(jdbcOutputFormat);
+                                        }));
+        source.output(new TestOutputFormat(jdbcOutputFormat));
         environment.execute();
 
         try (Connection dbConn = DriverManager.getConnection(getMetadata().getJdbcUrl());
@@ -178,17 +173,42 @@ class JdbcFullTest extends JdbcDataTestBase {
         try (Connection conn = getMetadata().getConnection();
                 Statement stat = conn.createStatement()) {
             stat.execute("DELETE FROM " + OUTPUT_TABLE);
-
-            stat.close();
-            conn.close();
         }
     }
 
     private static JdbcBatchStatementExecutor<Row> createSimpleRowExecutor(
-            String sql, int[] fieldTypes, boolean objectReuse) {
+            String sql, int[] fieldTypes) {
         JdbcStatementBuilder<Row> builder =
                 (st, record) -> setRecordToStatement(st, fieldTypes, record);
-        return JdbcBatchStatementExecutor.simple(
-                sql, builder, objectReuse ? Row::copy : Function.identity());
+        return JdbcBatchStatementExecutor.simple(sql, builder);
+    }
+
+    public static class TestOutputFormat implements OutputFormat<Row>, Serializable {
+        private final JdbcOutputFormat<Row, ?, ?> jdbcOutputFormat;
+
+        public TestOutputFormat(JdbcOutputFormat<Row, ?, ?> jdbcOutputFormat) {
+            this.jdbcOutputFormat = jdbcOutputFormat;
+        }
+
+        @Override
+        public void configure(Configuration configuration) {}
+
+        @Override
+        public void open(int i, int i1) throws IOException {
+            JdbcOutputSerializer<Row> serializer =
+                    JdbcOutputSerializer.of(TypeInformation.of(Row.class))
+                            .configure(getExecutionConfig(true));
+            this.jdbcOutputFormat.open(serializer);
+        }
+
+        @Override
+        public void writeRecord(Row row) throws IOException {
+            this.jdbcOutputFormat.writeRecord(row);
+        }
+
+        @Override
+        public void close() throws IOException {
+            this.jdbcOutputFormat.close();
+        }
     }
 }

--- a/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableSinkITCase.java
+++ b/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableSinkITCase.java
@@ -18,8 +18,10 @@
 
 package org.apache.flink.connector.jdbc.table;
 
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.tuple.Tuple4;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.jdbc.JdbcTestBase;
 import org.apache.flink.connector.jdbc.internal.GenericJdbcSinkFunction;
 import org.apache.flink.runtime.state.StateSnapshotContextSynchronousImpl;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -431,6 +433,8 @@ class JdbcDynamicTableSinkITCase extends AbstractTestBase {
         GenericJdbcSinkFunction<RowData> sinkFunction =
                 (GenericJdbcSinkFunction<RowData>) sinkProvider.createSinkFunction();
         sinkFunction.setRuntimeContext(new MockStreamingRuntimeContext(true, 1, 0));
+        sinkFunction.setInputType(
+                TypeInformation.of(GenericRowData.class), JdbcTestBase.getExecutionConfig(false));
         sinkFunction.open(new Configuration());
         sinkFunction.invoke(GenericRowData.of(1L), SinkContextUtil.forTimestamp(1));
         sinkFunction.invoke(GenericRowData.of(2L), SinkContextUtil.forTimestamp(1));

--- a/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcOutputFormatTest.java
+++ b/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcOutputFormatTest.java
@@ -18,9 +18,11 @@
 
 package org.apache.flink.connector.jdbc.table;
 
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.connector.jdbc.JdbcDataTestBase;
 import org.apache.flink.connector.jdbc.JdbcExecutionOptions;
 import org.apache.flink.connector.jdbc.internal.JdbcOutputFormat;
+import org.apache.flink.connector.jdbc.internal.JdbcOutputSerializer;
 import org.apache.flink.connector.jdbc.internal.options.JdbcConnectorOptions;
 import org.apache.flink.connector.jdbc.internal.options.JdbcDmlOptions;
 import org.apache.flink.table.api.DataTypes;
@@ -110,7 +112,10 @@ class JdbcOutputFormatTest extends JdbcDataTestBase {
                                             .setJdbcExecutionOptions(
                                                     JdbcExecutionOptions.builder().build())
                                             .build();
-                            outputFormat.open(0, 1);
+                            JdbcOutputSerializer<RowData> serializer =
+                                    JdbcOutputSerializer.of(TypeInformation.of(RowData.class))
+                                            .configure(getExecutionConfig(true));
+                            outputFormat.open(serializer);
                         })
                 .isInstanceOf(IOException.class)
                 .hasMessage(expectedMsg);
@@ -141,7 +146,11 @@ class JdbcOutputFormatTest extends JdbcDataTestBase {
                                             .setJdbcExecutionOptions(
                                                     JdbcExecutionOptions.builder().build())
                                             .build();
-                            outputFormat.open(0, 1);
+
+                            JdbcOutputSerializer<RowData> serializer =
+                                    JdbcOutputSerializer.of(TypeInformation.of(RowData.class))
+                                            .configure(getExecutionConfig(true));
+                            outputFormat.open(serializer);
                         })
                 .isInstanceOf(IllegalStateException.class);
     }
@@ -173,8 +182,10 @@ class JdbcOutputFormatTest extends JdbcDataTestBase {
                                             .setRowDataTypeInfo(rowDataTypeInfo)
                                             .build();
 
-                            setRuntimeContext(outputFormat, false);
-                            outputFormat.open(0, 1);
+                            JdbcOutputSerializer<RowData> serializer =
+                                    JdbcOutputSerializer.of(TypeInformation.of(RowData.class))
+                                            .configure(getExecutionConfig(true));
+                            outputFormat.open(serializer);
 
                             RowData row =
                                     buildGenericData(4, "hello", "world", 0.99, "imthewrongtype");
@@ -211,8 +222,11 @@ class JdbcOutputFormatTest extends JdbcDataTestBase {
                                                     JdbcExecutionOptions.builder().build())
                                             .setRowDataTypeInfo(rowDataTypeInfo)
                                             .build();
-                            setRuntimeContext(outputFormat, false);
-                            outputFormat.open(0, 1);
+
+                            JdbcOutputSerializer<RowData> serializer =
+                                    JdbcOutputSerializer.of(TypeInformation.of(RowData.class))
+                                            .configure(getExecutionConfig(true));
+                            outputFormat.open(serializer);
 
                             TestEntry entry = TEST_DATA[0];
                             RowData row =
@@ -252,8 +266,11 @@ class JdbcOutputFormatTest extends JdbcDataTestBase {
                                                     JdbcExecutionOptions.builder().build())
                                             .setRowDataTypeInfo(rowDataTypeInfo)
                                             .build();
-                            setRuntimeContext(outputFormat, true);
-                            outputFormat.open(0, 1);
+
+                            JdbcOutputSerializer<RowData> serializer =
+                                    JdbcOutputSerializer.of(TypeInformation.of(RowData.class))
+                                            .configure(getExecutionConfig(true));
+                            outputFormat.open(serializer);
 
                             TestEntry entry = TEST_DATA[0];
                             RowData row =
@@ -297,11 +314,11 @@ class JdbcOutputFormatTest extends JdbcDataTestBase {
                         .setJdbcExecutionOptions(JdbcExecutionOptions.builder().build())
                         .setRowDataTypeInfo(rowDataTypeInfo)
                         .build();
-        setRuntimeContext(outputFormat, true);
-        outputFormat.open(0, 1);
 
-        setRuntimeContext(outputFormat, true);
-        outputFormat.open(0, 1);
+        JdbcOutputSerializer<RowData> serializer =
+                JdbcOutputSerializer.of(TypeInformation.of(RowData.class))
+                        .configure(getExecutionConfig(true));
+        outputFormat.open(serializer);
 
         for (TestEntry entry : TEST_DATA) {
             outputFormat.writeRecord(
@@ -352,12 +369,15 @@ class JdbcOutputFormatTest extends JdbcDataTestBase {
                         .setJdbcExecutionOptions(executionOptions)
                         .setRowDataTypeInfo(rowDataTypeInfo)
                         .build();
-        setRuntimeContext(outputFormat, true);
-        outputFormat.open(0, 1);
+
+        JdbcOutputSerializer<RowData> serializer =
+                JdbcOutputSerializer.of(TypeInformation.of(RowData.class))
+                        .configure(getExecutionConfig(true));
+        outputFormat.open(serializer);
 
         try (Connection dbConn = DriverManager.getConnection(DERBY_EBOOKSHOP_DB.getJdbcUrl());
                 PreparedStatement statement = dbConn.prepareStatement(SELECT_ALL_NEWBOOKS_2)) {
-            outputFormat.open(0, 1);
+
             for (int i = 0; i < 2; ++i) {
                 outputFormat.writeRecord(
                         buildGenericData(
@@ -422,11 +442,15 @@ class JdbcOutputFormatTest extends JdbcDataTestBase {
                         .setJdbcExecutionOptions(executionOptions)
                         .setRowDataTypeInfo(rowDataTypeInfo)
                         .build();
-        setRuntimeContext(outputFormat, true);
+
+        JdbcOutputSerializer<RowData> serializer =
+                JdbcOutputSerializer.of(TypeInformation.of(RowData.class))
+                        .configure(getExecutionConfig(true));
+        outputFormat.open(serializer);
 
         try (Connection dbConn = DriverManager.getConnection(DERBY_EBOOKSHOP_DB.getJdbcUrl());
                 PreparedStatement statement = dbConn.prepareStatement(SELECT_ALL_NEWBOOKS_2)) {
-            outputFormat.open(0, 1);
+
             for (int i = 0; i < 2; ++i) {
                 outputFormat.writeRecord(
                         buildGenericData(
@@ -467,8 +491,11 @@ class JdbcOutputFormatTest extends JdbcDataTestBase {
                         .setJdbcExecutionOptions(JdbcExecutionOptions.builder().build())
                         .setRowDataTypeInfo(rowDataTypeInfo)
                         .build();
-        setRuntimeContext(outputFormat, true);
-        outputFormat.open(0, 1);
+
+        JdbcOutputSerializer<RowData> serializer =
+                JdbcOutputSerializer.of(TypeInformation.of(RowData.class))
+                        .configure(getExecutionConfig(true));
+        outputFormat.open(serializer);
 
         // write records
         for (int i = 0; i < 3; i++) {


### PR DESCRIPTION
This centralise the use of ExecutionConfig and the logic of if it is necessary to copy the record received or not.

Also fix the multiples copies if object reuse is enabled.