### PR TITLE
[FLINK-31437][docs] Fix wrong key 'lookup.cache.caching-missing-key' in 'jdbc.md'.

### DIFF
--- a/docs/content.zh/docs/connectors/table/jdbc.md
+++ b/docs/content.zh/docs/connectors/table/jdbc.md
@@ -234,7 +234,7 @@ ON myTopic.key = MyUserTable.id;
       使用该配置时 "lookup.cache" 必须设置为 "PARTIAL”。请参阅下面的 <a href="#lookup-cache">Lookup Cache</a> 部分了解更多详情。</td>
     </tr>
     <tr>
-      <td><h5>lookup.partial-cache.caching-missing-key</h5></td>
+      <td><h5>lookup.partial-cache.cache-missing-key</h5></td>
       <td>可选</td>
       <td style="word-wrap: break-word;">true</td>
       <td>Boolean</td>
@@ -315,7 +315,7 @@ ON myTopic.key = MyUserTable.id;
           <td>yes</td>
           <td style="word-wrap: break-word;">true</td>
           <td>Boolean</td>
-          <td>请配置 "lookup.cache" = "PARTIAL" 并使用 "lookup.partial-cache.caching-missing-key" 代替</td>
+          <td>请配置 "lookup.cache" = "PARTIAL" 并使用 "lookup.partial-cache.cache-missing-key" 代替</td>
         </tr>
     </tbody>
 <table>
@@ -362,7 +362,7 @@ lookup cache 的主要目的是用于提高时态表关联 JDBC 连接器的性�
 当缓存命中最大缓存行 `lookup.partial-cache.max-rows` 或当行超过 `lookup.partial-cache.expire-after-write` 或 `lookup.partial-cache.expire-after-access` 指定的最大存活时间时，缓存中的行将被设置为已过期。
 缓存中的记录可能不是最新的，用户可以将缓存记录超时设置为一个更小的值以获得更好的刷新数据，但这可能会增加发送到数据库的请求数。所以要做好吞吐量和正确性之间的平衡。
 
-默认情况下，flink 会缓存主键的空查询结果，你可以通过将 `lookup.partial-cache.caching-missing-key` 设置为 false 来切换行为。
+默认情况下，flink 会缓存主键的空查询结果，你可以通过将 `lookup.partial-cache.cache-missing-key` 设置为 false 来切换行为。
 
 <a name="idempotent-writes"></a>
 

--- a/docs/content/docs/connectors/table/jdbc.md
+++ b/docs/content/docs/connectors/table/jdbc.md
@@ -246,7 +246,7 @@ Connector Options
       "lookup.cache" must be set to "PARTIAL" to use this option. See the following <a href="#lookup-cache">Lookup Cache</a> section for more details. </td>
     </tr>
     <tr>
-      <td><h5>lookup.partial-cache.caching-missing-key</h5></td>
+      <td><h5>lookup.partial-cache.cache-missing-key</h5></td>
       <td>optional</td>
       <td>yes</td>
       <td style="word-wrap: break-word;">true</td>
@@ -333,7 +333,7 @@ These deprecated options has been replaced by new options listed above and will 
           <td>yes</td>
           <td style="word-wrap: break-word;">true</td>
           <td>Boolean</td>
-          <td>Please set "lookup.cache" = "PARTIAL" and use "lookup.partial-cache.caching-missing-key" instead.</td>
+          <td>Please set "lookup.cache" = "PARTIAL" and use "lookup.partial-cache.cache-missing-key" instead.</td>
         </tr>
     </tbody>
 <table>
@@ -372,7 +372,7 @@ When lookup cache is enabled, each process (i.e. TaskManager) will hold a cache.
 The oldest rows in cache will be expired when the cache hit to the max cached rows `lookup.partial-cache.max-rows` or when the row exceeds the max time to live specified by `lookup.partial-cache.expire-after-write` or `lookup.partial-cache.expire-after-access`.
 The cached rows might not be the latest, users can tune expiration options to a smaller value to have a better fresh data, but this may increase the number of requests send to database. So this is a balance between throughput and correctness.
 
-By default, flink will cache the empty query result for a Primary key, you can toggle the behaviour by setting `lookup.partial-cache.caching-missing-key` to false.
+By default, flink will cache the empty query result for a Primary key, you can toggle the behaviour by setting `lookup.partial-cache.cache-missing-key` to false.
 
 ### Idempotent Writes
 


### PR DESCRIPTION
 Fix wrong key 'lookup.cache.caching-missing-key' in 'jdbc.md'.