### PR TITLE
[FLINK-31624] Bump Flink version to 1.17.0

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -25,4 +25,4 @@ jobs:
   compile_and_test:
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
-      flink_version: 1.16.1
+      flink_version: 1.17.0

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -25,7 +25,7 @@ jobs:
     if: github.repository_owner == 'apache'
     strategy:
       matrix:
-        flink: [1.16-SNAPSHOT, 1.17-SNAPSHOT]
+        flink: [1.16-SNAPSHOT, 1.17-SNAPSHOT, 1.18-SNAPSHOT]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}

--- a/flink-connector-jdbc/src/test/resources/archunit.properties
+++ b/flink-connector-jdbc/src/test/resources/archunit.properties
@@ -29,3 +29,5 @@ freeze.store.default.allowStoreUpdate=true
 #freeze.refreeze=true
 
 freeze.store.default.path=archunit-violations
+
+archRule.failOnEmptyShould = false

--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,8 @@ under the License.
     </modules>
 
     <properties>
-        <flink.version>1.16.1</flink.version>
-        <flink.shaded.version>15.0</flink.shaded.version>
+        <flink.version>1.17.0</flink.version>
+        <flink.shaded.version>16.1</flink.shaded.version>
 
         <jackson-bom.version>2.13.4.20221013</jackson-bom.version>
         <junit4.version>4.13.2</junit4.version>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@ under the License.
         <junit4.version>4.13.2</junit4.version>
         <junit5.version>5.8.1</junit5.version>
         <assertj.version>3.21.0</assertj.version>
-        <archunit.version>0.22.0</archunit.version>
+        <archunit.version>1.0.1</archunit.version>
         <testcontainers.version>1.17.2</testcontainers.version>
         <mockito.version>2.21.0</mockito.version>
 


### PR DESCRIPTION
Bump Flink version to 1.17.0
Bump Flink Shaded to 16.1 (needed by Flink version)
Bump archunit to 1.0.1 and added new arch config to avoid fail when no classes founded for some rule.
"archRule.failOnEmptyShould = false"