### PR TITLE
[FLINK-31699][connector/jdbc] Use ORACLE_18 for OracleXaDatabase instead of ORACLE_21 to fix CI failure

### DIFF
--- a/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/databases/oracle/OracleXaDatabase.java
+++ b/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/databases/oracle/OracleXaDatabase.java
@@ -30,7 +30,7 @@ public interface OracleXaDatabase extends DatabaseTest, OracleImages {
 
     @Container
     OracleContainer CONTAINER =
-            new OracleContainer(ORACLE_21)
+            new OracleContainer(ORACLE_18)
                     .withStartupTimeoutSeconds(240)
                     .withConnectTimeoutSeconds(120)
                     .usingSid();


### PR DESCRIPTION
This PR fixed the test failure in the OracleExactlyOnceSinkE2eTest.