### PR TITLE
[FLINK-31820] Support data source sub-database and sub-table

### DIFF
--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/RdbDialects.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/RdbDialects.java
@@ -1,0 +1,30 @@
+package org.apache.flink.connector.jdbc;
+
+import org.apache.flink.connector.jdbc.dialect.JdbcDialect;
+import org.apache.flink.connector.jdbc.dialect.mysql.MySqlDialectFactory;
+import org.apache.flink.connector.jdbc.dialect.oracle.OracleDialectFactory;
+import org.apache.flink.connector.jdbc.dialect.psql.PostgresDialectFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class RdbDialects {
+
+    private static final Map<String, JdbcDialect> jdbcDialectMap = new HashMap<String, JdbcDialect>() {
+        {
+            put("jdbc:oracle", new OracleDialectFactory().create());
+            put("jdbc:mysql", new MySqlDialectFactory().create());
+            put("jdbc:postgres", new PostgresDialectFactory().create());
+        }
+    };
+
+    public static JdbcDialect get(String url) throws RuntimeException {
+        for (Map.Entry<String, JdbcDialect> item : jdbcDialectMap.entrySet()) {
+            String key = item.getKey();
+            if (url.contains(key)) {
+                return jdbcDialectMap.get(url);
+            }
+        }
+        throw new RuntimeException("当前数据源不支持分库分表!");
+    }
+}

--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/AbstractDialect.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/AbstractDialect.java
@@ -175,6 +175,23 @@ public abstract class AbstractDialect implements JdbcDialect {
         return "DELETE FROM " + quoteIdentifier(tableName) + " WHERE " + conditionClause;
     }
 
+    @Override
+    public String getSelectFromLikeStatement(String tableName, String[] selectFields, String[] tablePrefix) {
+        String selectExpressions =
+            Arrays.stream(selectFields)
+                .map(this::quoteIdentifier)
+                .collect(Collectors.joining(", "));
+        String fieldExpressions =
+            Arrays.stream(tablePrefix)
+                .map(f -> format("%s like :%s", quoteIdentifier(f), f))
+                .collect(Collectors.joining());
+        return "SELECT "
+            + selectExpressions
+            + " FROM "
+            + quoteIdentifier(tableName)
+            + (tablePrefix.length > 0  ? " WHERE " + fieldExpressions : "");
+    }
+
     /**
      * A simple {@code SELECT} statement.
      *

--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/JdbcDialect.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/JdbcDialect.java
@@ -133,6 +133,8 @@ public interface JdbcDialect extends Serializable {
      */
     String getDeleteStatement(String tableName, String[] conditionFields);
 
+    String getSelectFromLikeStatement(String tableName, String[] selectFields, String[] conditionFields);
+
     /**
      * Constructs the dialects select statement for fields with given conditions. The returned
      * string will be used as a {@link java.sql.PreparedStatement}. Fields in the statement must be

--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/split/JdbcMultiTableProvider.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/split/JdbcMultiTableProvider.java
@@ -1,0 +1,97 @@
+package org.apache.flink.connector.jdbc.split;
+
+import org.apache.flink.annotation.Experimental;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * In the scenario of sub-database sub-table, based on the results of the original data fragmentation, Serializable[][] is split twice
+ */
+@Experimental
+public class JdbcMultiTableProvider implements JdbcParameterValuesProvider  {
+
+    /**
+     * Correspondence between matching database connection and table
+     */
+    private List<TableItem> tables;
+
+
+    /**
+     * schema name
+     */
+    private String dbName;
+
+    /**
+     * The split result after the original jdbc data fragmentation configuration
+     */
+    private Serializable[][] partition;
+
+    public JdbcMultiTableProvider(String dbName, List<TableItem> tables) {
+        this.tables = tables;
+        this.dbName = dbName;
+    }
+
+    /**
+     * @return Returns the corresponding relationship between split fragments and data blocks, Serializable[partition][parameterValues]
+     * The startup partition is the shard index, and parameterValues is the data parameter corresponding to each shard.
+     */
+    @Override
+    public Serializable[][] getParameterValues() {
+        int tableNum = tables.stream().mapToInt(item -> item.getTable().size()).sum();
+        int splitCount = partition == null ? tableNum : tableNum * partition.length;
+        int paramLength = partition == null ? 2 : 4;
+        Serializable[][] parameters = new Serializable[splitCount][paramLength];
+        int splitIndex = 0;
+
+        for (TableItem tableItem : tables) {
+            for (String table : tableItem.getTable()) {
+                if (partition != null) {
+                    for (Serializable[] serializables : partition) {
+                        parameters[splitIndex][0] = tableItem.getUrl();
+                        parameters[splitIndex][1] = table;
+                        //数据分片配置
+                        parameters[splitIndex][2] = serializables[0];
+                        parameters[splitIndex][3] = serializables[1];
+                        splitIndex++;
+                    }
+                } else {
+                    parameters[splitIndex][0] = tableItem.getUrl();
+                    parameters[splitIndex][1] = table;
+                    splitIndex++;
+                }
+                parameters[splitIndex][2] = dbName;
+            }
+        }
+        return parameters;
+    }
+
+    public JdbcParameterValuesProvider withPartition(JdbcNumericBetweenParametersProvider jdbcNumericBetweenParametersProvider) {
+        if (null == jdbcNumericBetweenParametersProvider) {
+            return this;
+        }
+        this.partition = jdbcNumericBetweenParametersProvider.getParameterValues();
+        return this;
+    }
+
+    public static class TableItem {
+        private String url;
+        private List<String> table;
+
+        public String getUrl() {
+            return url;
+        }
+
+        public void setUrl(String url) {
+            this.url = url;
+        }
+
+        public List<String> getTable() {
+            return table;
+        }
+
+        public void setTable(List<String> table) {
+            this.table = table;
+        }
+    }
+}

--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcConnectorOptions.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcConnectorOptions.java
@@ -21,10 +21,12 @@ package org.apache.flink.connector.jdbc.table;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.connector.jdbc.split.JdbcMultiTableProvider;
 import org.apache.flink.table.connector.source.lookup.LookupOptions;
 import org.apache.flink.table.factories.FactoryUtil;
 
 import java.time.Duration;
+import java.util.List;
 
 /** Options for the JDBC connector. */
 @PublicEvolving

--- a/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableFactoryTest.java
+++ b/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableFactoryTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.connector.jdbc.JdbcExecutionOptions;
 import org.apache.flink.connector.jdbc.internal.options.JdbcConnectorOptions;
 import org.apache.flink.connector.jdbc.internal.options.JdbcDmlOptions;
 import org.apache.flink.connector.jdbc.internal.options.JdbcReadOptions;
+import org.apache.flink.connector.jdbc.split.JdbcMultiTableProvider;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ResolvedSchema;
@@ -35,9 +36,11 @@ import org.apache.flink.table.connector.source.lookup.cache.DefaultLookupCache;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSink;
@@ -247,6 +250,14 @@ class JdbcDynamicTableFactoryTest {
 
         DynamicTableSink actual = createTableSink(SCHEMA, properties);
 
+        List<JdbcMultiTableProvider.TableItem> tableItemList = new ArrayList<>();
+        String url = "jdbc:mysql://localhost:3306/order_([0-9]{1,}),jdbc:mysql://localhost:3306/order_([0-9]{1,})";
+        String tableName = "order_([0-9]{1,})";
+        //数据查询模板,String table = params[1].toString();
+//        String queryTemplate = queryTemplate(pa, dialect);
+        JdbcMultiTableProvider.TableItem item = new JdbcMultiTableProvider.TableItem();
+//        item.setUrl(url);
+//        item.setTable();
         JdbcConnectorOptions options =
                 JdbcConnectorOptions.builder()
                         .setDBUrl("jdbc:derby:memory:mydb")


### PR DESCRIPTION
related to [FLINK-31820](https://issues.apache.org/jira/browse/FLINK-31820)

#### Background & Motivation

Hi, community. As I develop full-database synchronization syntax in the company to reduce the increase in the number of connections when multiple data sources are synchronized, I find that traditional databases (Mysql, Postgres, Oracle) need to support the function of sub-database and sub-table. It supports data source sub-database sub-table on top of existing projects

#### Goals
- Support data source sub-database sub-table
- When the sub-database and table functions are realized, the original data fragments allocated according to the partition are guaranteed to be available
- Prioritize to ensure that Mysql, Postgres, Oracle support sub-database sub-table

#### Change

- Every time JdbcRowDataInputFormat switches fragments, it will call open(InputSplit inputSplit) once (corresponding to closing the current data fragmentation method: close()), the value of inputSplit corresponds to the value of x in Serializable[x][y] is incremented, and each parallel The instance will not be executed repeatedly. For example, if there are 1024 split tables and each table has 2 data splits, then the value range of inputSplit.getSplitNumber() is: [0~2047]. Therefore, when the database is divided into tables, it should be ensured that the query logic of each table after the database and table is consistent with the query logic of the original single database and single table.
- JdbcMultiTableProvider needs to split the Serializable[][] twice based on the results of the original data fragmentation, according to the sub-database and sub-table, to ensure that JdbcRowDataInputFormat can obtain the split table information

#### Design
According to the configured url and table_name expressions, the basic encoding steps are as follows:

- Query all schemas in the database
- Match the schema by regular
- Query matches the table under the schema
- By regular matching table
- Return the corresponding relationship between the database url and the table: List<TableItem>