### PR TITLE
Fix duplicated data on retrying

### DIFF
--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/executor/InsertOrUpdateJdbcExecutor.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/executor/InsertOrUpdateJdbcExecutor.java
@@ -99,6 +99,9 @@ public final class InsertOrUpdateJdbcExecutor<R, K, V> implements JdbcBatchState
     @Override
     public void executeBatch() throws SQLException {
         if (!batch.isEmpty()) {
+			existStatement.clearParameters();
+			updateStatement.clearParameters();
+			insertStatement.clearParameters();
             for (Map.Entry<K, V> entry : batch.entrySet()) {
                 processOneRowInBatch(entry.getKey(), entry.getValue());
             }

--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/executor/KeyedBatchStatementExecutor.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/executor/KeyedBatchStatementExecutor.java
@@ -70,6 +70,7 @@ class KeyedBatchStatementExecutor<T, K> implements JdbcBatchStatementExecutor<T>
     @Override
     public void executeBatch() throws SQLException {
         if (!batch.isEmpty()) {
+			st.clearParameters();
             for (K entry : batch) {
                 parameterSetter.accept(st, entry);
                 st.addBatch();

--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/executor/SimpleBatchStatementExecutor.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/executor/SimpleBatchStatementExecutor.java
@@ -66,6 +66,7 @@ class SimpleBatchStatementExecutor<T, V> implements JdbcBatchStatementExecutor<T
     @Override
     public void executeBatch() throws SQLException {
         if (!batch.isEmpty()) {
+			st.clearParameters();
             for (V r : batch) {
                 parameterSetter.accept(st, r);
                 st.addBatch();


### PR DESCRIPTION
When SQL execution fails, Flink will retry. At this point, the PreparedStatement still contains the previously added parameters, resulting in data duplication.

Should we always clear previously added parameters on 'executeBatch' method to avoid this?