### PR TITLE
[FLINK-32313] Remove usage of flink-shaded from the code, add deprecation on checkstyle level

### DIFF
--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/databases/cratedb/catalog/CrateDBCatalog.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/databases/cratedb/catalog/CrateDBCatalog.java
@@ -18,21 +18,19 @@
 
 package org.apache.flink.connector.jdbc.databases.cratedb.catalog;
 
+import org.apache.commons.compress.utils.Lists;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.connector.jdbc.databases.postgres.catalog.PostgresCatalog;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
-
-import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableList;
-
-import org.apache.commons.compress.utils.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -75,7 +73,7 @@ public class CrateDBCatalog extends PostgresCatalog {
 
     @Override
     public List<String> listDatabases() throws CatalogException {
-        return ImmutableList.of(DEFAULT_DATABASE);
+        return Collections.singletonList(DEFAULT_DATABASE);
     }
 
     // ------ schemas ------

--- a/tools/maven/checkstyle.xml
+++ b/tools/maven/checkstyle.xml
@@ -213,16 +213,8 @@ This file is based on the checkstyle file of Apache Beam.
 					  value="autovalue.shaded, avro.shaded, com.google.api.client.repackaged, com.google.appengine.repackaged"/>
 		</module>
 		<module name="IllegalImport">
-			<property name="illegalPkgs" value="org.codehaus.jackson"/>
-			<message key="import.illegal" value="{0}; Use flink-shaded-jackson instead."/>
-		</module>
-		<module name="IllegalImport">
-			<property name="illegalPkgs" value="org.objectweb.asm"/>
-			<message key="import.illegal" value="{0}; Use flink-shaded-asm instead."/>
-		</module>
-		<module name="IllegalImport">
-			<property name="illegalPkgs" value="io.netty"/>
-			<message key="import.illegal" value="{0}; Use flink-shaded-netty instead."/>
+			<property name="illegalPkgs" value="org.apache.flink.shaded"/>
+			<message key="import.illegal" value="{0}; Flink-jdbc-connector should not use flink-shaded."/>
 		</module>
 
 		<module name="RedundantModifier">


### PR DESCRIPTION
After that any code with import of `flink-shaded` should fail at compilation on checkstyle task