### PR TITLE
[hotfix] Set fork count to 1 for IT cases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@ under the License.
         <log4j.version>2.17.2</log4j.version>
 
         <flink.parent.artifactId>flink-connector-jdbc-parent</flink.parent.artifactId>
+        <flink.forkCountITCase>1</flink.forkCountITCase>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
By default it inherints `flink.forkCountITCase` == 2 from flink.
The PR sets it to 1 
it looks sqlserver container has issues with starting in several surefire forks...
Based on https://github.com/MartijnVisser/flink-connector-jdbc/actions/runs/5265349453/jobs/9517854060
```
"main" #1 prio=5 os_prio=0 cpu=1965.96ms elapsed=2568.93s tid=0x00007f84a0027000 nid=0x1c82 runnable  [0x00007f84a41fc000]
   java.lang.Thread.State: RUNNABLE
	at java.net.SocketInputStream.socketRead0(java.base@11.0.19/Native Method)
	at java.net.SocketInputStream.socketRead(java.base@11.0.19/SocketInputStream.java:115)
	at java.net.SocketInputStream.read(java.base@11.0.19/SocketInputStream.java:168)
	at java.net.SocketInputStream.read(java.base@11.0.19/SocketInputStream.java:140)
	at com.microsoft.sqlserver.jdbc.TDSChannel$ProxyInputStream.readInternal(IOBuffer.java:1192)
	- locked <0x00000000930e38f0> (a com.microsoft.sqlserver.jdbc.TDSChannel$ProxyInputStream)
	at com.microsoft.sqlserver.jdbc.TDSChannel$ProxyInputStream.read(IOBuffer.java:1179)
	at com.microsoft.sqlserver.jdbc.TDSChannel.read(IOBuffer.java:2307)
	- locked <0x00000000930e38f0> (a com.microsoft.sqlserver.jdbc.TDSChannel$ProxyInputStream)
	at com.microsoft.sqlserver.jdbc.SQLServerConnection.Prelogin(SQLServerConnection.java:3391)
	at com.microsoft.sqlserver.jdbc.SQLServerConnection.connectHelper(SQLServerConnection.java:3200)
	at com.microsoft.sqlserver.jdbc.SQLServerConnection.login(SQLServerConnection.java:2833)
	at com.microsoft.sqlserver.jdbc.SQLServerConnection.connectInternal(SQLServerConnection.java:2671)
	at com.microsoft.sqlserver.jdbc.SQLServerConnection.connect(SQLServerConnection.java:1640)
	at com.microsoft.sqlserver.jdbc.SQLServerDriver.connect(SQLServerDriver.java:936)
	at org.testcontainers.containers.JdbcDatabaseContainer.createConnection(JdbcDatabaseContainer.java:253)
	at org.testcontainers.containers.JdbcDatabaseContainer.createConnection(JdbcDatabaseContainer.java:218)
	at org.testcontainers.containers.JdbcDatabaseContainer.waitUntilContainerStarted(JdbcDatabaseContainer.java:158)
	at org.testcontainers.containers.GenericContainer.tryStart(GenericContainer.java:490)
	at org.testcontainers.containers.GenericContainer.lambda$doStart$0(GenericContainer.java:344)
	at org.testcontainers.containers.GenericContainer$$Lambda$532/0x00000001003d1440.call(Unknown Source)
	at org.rnorth.ducttape.unreliables.Unreliables.retryUntilSuccess(Unreliables.java:81)
	at org.testcontainers.containers.GenericContainer.doStart(GenericContainer.java:334)
	at org.testcontainers.containers.GenericContainer.start(GenericContainer.java:322)
	at org.apache.flink.connector.jdbc.testutils.databases.sqlserver.SqlServerDatabase$SqlServerContainer.start(SqlServerDatabase.java:81)
	at org.apache.flink.connector.jdbc.testutils.databases.sqlserver.SqlServerDatabase.startDatabase(SqlServerDatabase.java:52)
	at org.apache.flink.connector.jdbc.testutils.DatabaseExtension.beforeAll(DatabaseExtension.java:122)
...
```

