### PR TITLE
Update AbstractPostgresCompatibleDialect.java

### DIFF
--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/AbstractPostgresCompatibleDialect.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/AbstractPostgresCompatibleDialect.java
@@ -69,7 +69,13 @@ public abstract class AbstractPostgresCompatibleDialect extends AbstractDialect 
 
     @Override
     public String quoteIdentifier(String identifier) {
-        return identifier;
+    	if (identifier.contains(".")) {
+    		String[] ids = identifier.split("\\.");
+    		return Arrays.stream(ids)
+			             .map(this::quoteIdentifier)
+			             .collect(Collectors.joining(", "));
+    	}
+        return "\"" + identifier + "\"";
     }
 
     @Override


### PR DESCRIPTION
When there is a conflict between a field name and a keyword in a PostgreSQL table, it is necessary to use quotation marks.