### PR TITLE
[FLINK-33069]Mysql and Postgres catalog support url extra parameters

### DIFF
--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/AbstractJdbcCatalog.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/AbstractJdbcCatalog.java
@@ -92,6 +92,7 @@ public abstract class AbstractJdbcCatalog extends AbstractCatalog {
     protected final String pwd;
     protected final String baseUrl;
     protected final String defaultUrl;
+    protected final String extraUrlParam;
 
     public AbstractJdbcCatalog(
             ClassLoader userClassLoader,
@@ -99,7 +100,8 @@ public abstract class AbstractJdbcCatalog extends AbstractCatalog {
             String defaultDatabase,
             String username,
             String pwd,
-            String baseUrl) {
+            String baseUrl,
+            String extraUrlParam) {
         super(catalogName, defaultDatabase);
 
         checkNotNull(userClassLoader);
@@ -112,8 +114,13 @@ public abstract class AbstractJdbcCatalog extends AbstractCatalog {
         this.userClassLoader = userClassLoader;
         this.username = username;
         this.pwd = pwd;
+        this.extraUrlParam = extraUrlParam;
         this.baseUrl = baseUrl.endsWith("/") ? baseUrl : baseUrl + "/";
-        this.defaultUrl = this.baseUrl + defaultDatabase;
+        this.defaultUrl = initDefaultUrl(this.baseUrl, defaultDatabase, extraUrlParam);
+    }
+
+    protected String initDefaultUrl(String baseUrl, String defaultDatabase, String extraUrlParam) {
+        return baseUrl + defaultDatabase + extraUrlParam;
     }
 
     @Override
@@ -246,7 +253,7 @@ public abstract class AbstractJdbcCatalog extends AbstractCatalog {
         }
 
         String databaseName = tablePath.getDatabaseName();
-        String dbUrl = baseUrl + databaseName;
+        String dbUrl = defaultUrl;
 
         try (Connection conn = DriverManager.getConnection(dbUrl, username, pwd)) {
             DatabaseMetaData metaData = conn.getMetaData();

--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/JdbcCatalog.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/JdbcCatalog.java
@@ -74,11 +74,28 @@ public class JdbcCatalog extends AbstractJdbcCatalog {
             String username,
             String pwd,
             String baseUrl) {
-        super(userClassLoader, catalogName, defaultDatabase, username, pwd, baseUrl);
+        this(userClassLoader, catalogName, defaultDatabase, username, pwd, baseUrl, "");
+    }
+
+    public JdbcCatalog(
+            ClassLoader userClassLoader,
+            String catalogName,
+            String defaultDatabase,
+            String username,
+            String pwd,
+            String baseUrl,
+            String extraUrlParam) {
+        super(userClassLoader, catalogName, defaultDatabase, username, pwd, baseUrl, extraUrlParam);
 
         internal =
                 JdbcCatalogUtils.createCatalog(
-                        userClassLoader, catalogName, defaultDatabase, username, pwd, baseUrl);
+                        userClassLoader,
+                        catalogName,
+                        defaultDatabase,
+                        username,
+                        pwd,
+                        baseUrl,
+                        extraUrlParam);
     }
 
     // ------ databases -----

--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/JdbcCatalogUtils.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/JdbcCatalogUtils.java
@@ -48,18 +48,31 @@ public class JdbcCatalogUtils {
             String defaultDatabase,
             String username,
             String pwd,
-            String baseUrl) {
+            String baseUrl,
+            String extraUrlParam) {
         JdbcDialect dialect = JdbcDialectLoader.load(baseUrl, userClassLoader);
 
         if (dialect instanceof PostgresDialect) {
             return new PostgresCatalog(
-                    userClassLoader, catalogName, defaultDatabase, username, pwd, baseUrl);
+                    userClassLoader,
+                    catalogName,
+                    defaultDatabase,
+                    username,
+                    pwd,
+                    baseUrl,
+                    extraUrlParam);
         } else if (dialect instanceof CrateDBDialect) {
             return new CrateDBCatalog(
                     userClassLoader, catalogName, defaultDatabase, username, pwd, baseUrl);
         } else if (dialect instanceof MySqlDialect) {
             return new MySqlCatalog(
-                    userClassLoader, catalogName, defaultDatabase, username, pwd, baseUrl);
+                    userClassLoader,
+                    catalogName,
+                    defaultDatabase,
+                    username,
+                    pwd,
+                    baseUrl,
+                    extraUrlParam);
         } else {
             throw new UnsupportedOperationException(
                     String.format("Catalog for '%s' is not supported yet.", dialect));

--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/factory/JdbcCatalogFactory.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/factory/JdbcCatalogFactory.java
@@ -32,6 +32,7 @@ import java.util.Set;
 
 import static org.apache.flink.connector.jdbc.catalog.factory.JdbcCatalogFactoryOptions.BASE_URL;
 import static org.apache.flink.connector.jdbc.catalog.factory.JdbcCatalogFactoryOptions.DEFAULT_DATABASE;
+import static org.apache.flink.connector.jdbc.catalog.factory.JdbcCatalogFactoryOptions.EXTRA_URL_PARAM;
 import static org.apache.flink.connector.jdbc.catalog.factory.JdbcCatalogFactoryOptions.PASSWORD;
 import static org.apache.flink.connector.jdbc.catalog.factory.JdbcCatalogFactoryOptions.USERNAME;
 import static org.apache.flink.table.factories.FactoryUtil.PROPERTY_VERSION;
@@ -60,6 +61,7 @@ public class JdbcCatalogFactory implements CatalogFactory {
     public Set<ConfigOption<?>> optionalOptions() {
         final Set<ConfigOption<?>> options = new HashSet<>();
         options.add(PROPERTY_VERSION);
+        options.add(EXTRA_URL_PARAM);
         return options;
     }
 
@@ -75,6 +77,7 @@ public class JdbcCatalogFactory implements CatalogFactory {
                 helper.getOptions().get(DEFAULT_DATABASE),
                 helper.getOptions().get(USERNAME),
                 helper.getOptions().get(PASSWORD),
-                helper.getOptions().get(BASE_URL));
+                helper.getOptions().get(BASE_URL),
+                helper.getOptions().get(EXTRA_URL_PARAM));
     }
 }

--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/factory/JdbcCatalogFactoryOptions.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/factory/JdbcCatalogFactoryOptions.java
@@ -43,6 +43,8 @@ public class JdbcCatalogFactoryOptions {
 
     public static final ConfigOption<String> BASE_URL =
             ConfigOptions.key("base-url").stringType().noDefaultValue();
+    public static final ConfigOption<String> EXTRA_URL_PARAM =
+            ConfigOptions.key("extra-url-param").stringType().defaultValue("");
 
     private JdbcCatalogFactoryOptions() {}
 }

--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/databases/mysql/catalog/MySqlCatalog.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/databases/mysql/catalog/MySqlCatalog.java
@@ -67,7 +67,18 @@ public class MySqlCatalog extends AbstractJdbcCatalog {
             String username,
             String pwd,
             String baseUrl) {
-        super(userClassLoader, catalogName, defaultDatabase, username, pwd, baseUrl);
+        this(userClassLoader, catalogName, defaultDatabase, username, pwd, baseUrl, "");
+    }
+
+    public MySqlCatalog(
+            ClassLoader userClassLoader,
+            String catalogName,
+            String defaultDatabase,
+            String username,
+            String pwd,
+            String baseUrl,
+            String extraUrlParam) {
+        super(userClassLoader, catalogName, defaultDatabase, username, pwd, baseUrl, extraUrlParam);
 
         String driverVersion =
                 Preconditions.checkNotNull(getDriverVersion(), "Driver version must not be null.");

--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/databases/postgres/catalog/PostgresCatalog.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/databases/postgres/catalog/PostgresCatalog.java
@@ -86,7 +86,27 @@ public class PostgresCatalog extends AbstractJdbcCatalog {
                 username,
                 pwd,
                 baseUrl,
-                new PostgresTypeMapper());
+                new PostgresTypeMapper(),
+                "");
+    }
+
+    public PostgresCatalog(
+            ClassLoader userClassLoader,
+            String catalogName,
+            String defaultDatabase,
+            String username,
+            String pwd,
+            String baseUrl,
+            String extraUrlParam) {
+        this(
+                userClassLoader,
+                catalogName,
+                defaultDatabase,
+                username,
+                pwd,
+                baseUrl,
+                new PostgresTypeMapper(),
+                extraUrlParam);
     }
 
     protected PostgresCatalog(
@@ -97,7 +117,27 @@ public class PostgresCatalog extends AbstractJdbcCatalog {
             String pwd,
             String baseUrl,
             JdbcDialectTypeMapper dialectTypeMapper) {
-        super(userClassLoader, catalogName, defaultDatabase, username, pwd, baseUrl);
+        this(
+                userClassLoader,
+                catalogName,
+                defaultDatabase,
+                username,
+                pwd,
+                baseUrl,
+                dialectTypeMapper,
+                "");
+    }
+
+    protected PostgresCatalog(
+            ClassLoader userClassLoader,
+            String catalogName,
+            String defaultDatabase,
+            String username,
+            String pwd,
+            String baseUrl,
+            JdbcDialectTypeMapper dialectTypeMapper,
+            String extraUrlParam) {
+        super(userClassLoader, catalogName, defaultDatabase, username, pwd, baseUrl, extraUrlParam);
         this.dialectTypeMapper = dialectTypeMapper;
     }
 


### PR DESCRIPTION
Mysql and Postgres catalog support url extra parameters

CREATE CATALOG mymysql WITH(
'type' = 'jdbc',
'default-database' = 'test',
'username' = 'root',
'password' = 'xxx',
'base-url' = 'jdbc:mysql://xxx:53309',
'extra-url-param' = '?characterEncoding=utf8'
);

If used in this way, the URLs of all tables obtained from this catalog are: jdbc:mysql://xxx:53309?characterEncoding=utf8