### PR TITLE
[FLINK-33378] Prepare actions for flink version 1.18

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -25,7 +25,7 @@ jobs:
   compile_and_test:
     strategy:
       matrix:
-        flink: [1.17-SNAPSHOT, 1.18-SNAPSHOT]
+        flink: [1.16-SNAPSHOT, 1.17-SNAPSHOT, 1.18-SNAPSHOT]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -42,7 +42,7 @@ jobs:
           flink: 1.17.1,
           branch: v3.1
         }, {
-          flink: 1.18-SNAPSHOT,
+          flink: 1.18.0,
           branch: v3.1
         }]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils

--- a/pom.xml
+++ b/pom.xml
@@ -47,14 +47,14 @@ under the License.
     </modules>
 
     <properties>
-        <flink.version>1.17.0</flink.version>
+        <flink.version>1.16.2</flink.version>
 
         <jackson-bom.version>2.13.4.20221013</jackson-bom.version>
         <junit4.version>4.13.2</junit4.version>
-        <junit5.version>5.9.1</junit5.version>
-        <assertj.version>3.23.1</assertj.version>
-        <testcontainers.version>1.18.2</testcontainers.version>
-        <mockito.version>2.21.0</mockito.version>
+        <junit5.version>5.10.1</junit5.version>
+        <assertj.version>3.24.2</assertj.version>
+        <testcontainers.version>1.19.3</testcontainers.version>
+        <mockito.version>3.12.4</mockito.version>
 
         <japicmp.referenceVersion>3.0.0-1.16</japicmp.referenceVersion>
 
@@ -301,6 +301,13 @@ under the License.
                 <version>1.23.0</version>
             </dependency>
 
+            <!-- For dependency convergence -->
+            <dependency>
+                <groupId>org.xerial.snappy</groupId>
+                <artifactId>snappy-java</artifactId>
+                <version>1.1.10.4</version>
+            </dependency>
+
             <!-- For dependency convergence on mockito/powermock mismatch -->
             <dependency>
                 <groupId>net.bytebuddy</groupId>
@@ -313,6 +320,20 @@ under the License.
                 <groupId>net.bytebuddy</groupId>
                 <artifactId>byte-buddy-agent</artifactId>
                 <version>1.12.10</version>
+            </dependency>
+
+            <!-- For dependency convergence on crate-jdbc mismatch -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>31.1-jre</version>
+            </dependency>
+
+            <!-- For dependency convergence on crate-jdbc mismatch -->
+            <dependency>
+                <groupId>org.checkerframework</groupId>
+                <artifactId>checker-qual</artifactId>
+                <version>3.12.0</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Changes made:

- downgrade flink version on pom to match rule of minimum supported version
- added validation on PRs for 1.16 (this is already on weekly)
- bump version from 1.18-SNAPSHOT to 1.18.0 on all gitactions
- bump the version of some test dependencies as Junit5, assertj, testcontainers and mockito


Note:
- version 1.19-SNAPSHOT is not added to CI because of [this](https://github.com/apache/flink-connector-jdbc/pull/76#issuecomment-1822864807)