### PR TITLE
[FLINK-33800][JDBC/Connector] Allow passing parameters to database via jdbc url

### DIFF
--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/databases/cratedb/catalog/CrateDBCatalog.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/databases/cratedb/catalog/CrateDBCatalog.java
@@ -116,7 +116,8 @@ public class CrateDBCatalog extends PostgresCatalog {
         }
 
         String searchPath =
-                extractColumnValuesBySQL(baseUrl + DEFAULT_DATABASE, "show search_path", 1, null)
+                extractColumnValuesBySQL(
+                                urlFunction.apply(DEFAULT_DATABASE), "show search_path", 1, null)
                         .get(0);
         String[] schemas = searchPath.split("\\s*,\\s*");
 

--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/databases/mysql/catalog/MySqlCatalog.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/databases/mysql/catalog/MySqlCatalog.java
@@ -99,7 +99,7 @@ public class MySqlCatalog extends AbstractJdbcCatalog {
         }
 
         return extractColumnValuesBySQL(
-                baseUrl + databaseName,
+                urlFunction.apply(databaseName),
                 "SELECT TABLE_NAME FROM information_schema.`TABLES` WHERE TABLE_SCHEMA = ?",
                 1,
                 null,

--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/databases/postgres/catalog/PostgresCatalog.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/databases/postgres/catalog/PostgresCatalog.java
@@ -152,7 +152,7 @@ public class PostgresCatalog extends AbstractJdbcCatalog {
             throw new DatabaseNotExistException(getName(), databaseName);
         }
 
-        final String url = baseUrl + databaseName;
+        final String url = urlFunction.apply(databaseName);
         try (Connection conn = DriverManager.getConnection(url, username, pwd)) {
             // get all schemas
             List<String> schemas;


### PR DESCRIPTION
The idea is pretty straightforward: from one side there is a jdbc url which is normally is provided by most of the dbs providers to connect to. 
From the other side for some,  probably historical reasons, there a separate property for default database which is used for default url.

To not break former behaviour it is possible to specify either database in jdbcurl or database with extra parameters only if database is same as ifor a dedicated property for default database. 
In fact I tend to think to mark it as a deprecated since all the info could be extracted from jdbc url