### PR TITLE
[FLINK-33883][jdbc] Bump CI flink version on flink-connector-jdbc to support flink 1.19

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -30,6 +30,8 @@ jobs:
         include:
           - flink: 1.18-SNAPSHOT
             jdk: '8, 11, 17'
+          - flink: 1.19-SNAPSHOT
+            jdk: '8, 11, 17'
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -31,7 +31,7 @@ jobs:
           - flink: 1.18-SNAPSHOT
             jdk: '8, 11, 17'
           - flink: 1.19-SNAPSHOT
-            jdk: '8, 11, 17'
+            jdk: '8, 11, 17, 21'
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -38,7 +38,7 @@ jobs:
           branch: main
         }, {
           flink: 1.19-SNAPSHOT,
-          jdk: '8, 11, 17',
+          jdk: '8, 11, 17, 21',
           branch: main
         }, {
           flink: 1.16.2,

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -37,6 +37,10 @@ jobs:
           jdk: '8, 11, 17',
           branch: main
         }, {
+          flink: 1.19-SNAPSHOT,
+          jdk: '8, 11, 17',
+          branch: main
+        }, {
           flink: 1.16.2,
           branch: v3.1
         }, {

--- a/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcTablePlanTest.java
+++ b/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcTablePlanTest.java
@@ -22,16 +22,21 @@ import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.planner.utils.StreamTableTestUtil;
 import org.apache.flink.table.planner.utils.TableTestBase;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.rules.TestName;
 
 /** Plan tests for JDBC connector, for example, testing projection push down. */
 public class JdbcTablePlanTest extends TableTestBase {
-    // TODO: Update to junit5 after TableTestBase migrated (maybe copy the class?)
+
     private final StreamTableTestUtil util = streamTestUtil(TableConfig.getDefault());
 
-    @Before
-    public void setup() {
+    private TestInfo testInfo;
+
+    @BeforeEach
+    public void setup(TestInfo testInfo) {
+        this.testInfo = testInfo;
         util.tableEnv()
                 .executeSql(
                         "CREATE TABLE jdbc ("
@@ -63,5 +68,15 @@ public class JdbcTablePlanTest extends TableTestBase {
     public void testFilterPushdown() {
         util.verifyExecPlan(
                 "SELECT id, time_col, real_col FROM jdbc WHERE id = 900001 AND time_col <> TIME '11:11:11' OR double_col >= -1000.23");
+    }
+
+    // A workaround to get the test method name for flink versions not completely migrated to JUnit5
+    public TestName name() {
+        return new TestName() {
+            @Override
+            public String getMethodName() {
+                return testInfo.getTestMethod().get().getName();
+            }
+        };
     }
 }

--- a/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcTablePlanTest.java
+++ b/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcTablePlanTest.java
@@ -70,7 +70,10 @@ public class JdbcTablePlanTest extends TableTestBase {
                 "SELECT id, time_col, real_col FROM jdbc WHERE id = 900001 AND time_col <> TIME '11:11:11' OR double_col >= -1000.23");
     }
 
-    // A workaround to get the test method name for flink versions not completely migrated to JUnit5
+    /**
+     * Get the test method name, in order to adapt to {@link TableTestBase} that has not migrated to
+     * Junit5. Remove it when dropping support of Flink 1.18.
+     */
     public TestName name() {
         return new TestName() {
             @Override


### PR DESCRIPTION
[FLINK-33883][jdbc] Bump CI flink version on flink-connector-jdbc to support flink 1.19.