### PR TITLE
[FLINK-33952][FLINK-33787][jdbc] Java 17 support for jdbc connector

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -25,7 +25,12 @@ jobs:
   compile_and_test:
     strategy:
       matrix:
-        flink: [1.17.0, 1.18-SNAPSHOT]
+        flink: [1.17-SNAPSHOT]
+        jdk: [ '8, 11' ]
+        include:
+          - flink: 1.18-SNAPSHOT
+            jdk: '8, 11, 17'
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}
+      jdk_version: ${{ matrix.jdk }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -26,8 +26,13 @@ jobs:
     if: github.repository_owner == 'apache'
     strategy:
       matrix:
-        flink: [1.16-SNAPSHOT, 1.17-SNAPSHOT, 1.18-SNAPSHOT]
+        flink: [1.16-SNAPSHOT, 1.17-SNAPSHOT]
+        jdk: ['8, 11']
+        include:
+          - flink: 1.18-SNAPSHOT
+            jdk: '8, 11, 17'
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}
+      jdk_version: ${{ matrix.jdk }}
       run_dependency_convergence: false

--- a/flink-connector-jdbc/pom.xml
+++ b/flink-connector-jdbc/pom.xml
@@ -40,6 +40,11 @@ under the License.
 		<assertj.version>3.23.1</assertj.version>
 		<postgres.version>42.5.1</postgres.version>
 		<oracle.version>21.8.0.0</oracle.version>
+		<byte-buddy.version>1.12.10</byte-buddy.version>
+		<surefire.module.config> <!-- required by
+		Db2ExactlyOnceSinkE2eTest --> --add-opens=java.base/java.util=ALL-UNNAMED <!--
+		SimpleJdbcConnectionProviderDriverClassConcurrentLoadingITCase--> --add-opens=java.base/java.lang=ALL-UNNAMED
+		</surefire.module.config>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,9 @@ under the License.
 
         <flink.parent.artifactId>flink-connector-jdbc-parent</flink.parent.artifactId>
         <flink.forkCountITCase>1</flink.forkCountITCase>
+        <!-- These 2 properties should be removed together with upgrade of flink-connector-parent to 1.1.x -->
+        <flink.surefire.baseArgLine>-XX:+UseG1GC -Xms256m -XX:+IgnoreUnrecognizedVMOptions ${surefire.module.config}</flink.surefire.baseArgLine>
+        <surefire.module.config/>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
The PR is to enable Java 17 checks for v3.1 (Flink 1.18)
this is a backport of https://github.com/apache/flink-connector-jdbc/pull/82