### PR TITLE
[hotfix] Add jakarta.activation required after changes in Flink main repo

### DIFF
--- a/flink-connector-jdbc/pom.xml
+++ b/flink-connector-jdbc/pom.xml
@@ -248,7 +248,12 @@ under the License.
 			<artifactId>flink-architecture-tests-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-
+		<dependency>
+			<groupId>jakarta.activation</groupId>
+			<artifactId>jakarta.activation-api</artifactId>
+			<version>1.2.1</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<dependencyManagement>


### PR DESCRIPTION
The reason is this line https://github.com/apache/flink/blame/a41229b24d82e8c561350c42d8a98dfb865c3f69/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/TestingTierConsumerAgent.java#L28
added within https://github.com/apache/flink/pull/23927

now we need to have this dependency for tests to continue build it with jdk17+

P.S. to reproduce problem locally 
```
mvn clean install -Dflink.version=1.19-SNAPSHOT
```
(assuming that it will be run with jdk17 or jdk21 + assuming that either there is no builds in local maven cache of Flink 1.19-SNAPSHOT or there is a build for latest commit)