### PR TITLE
[FLINK-34215] FLIP-377: Support fine-grained configuration to control filter push down for JDBC Connector

### DIFF
--- a/docs/content.zh/docs/connectors/table/jdbc.md
+++ b/docs/content.zh/docs/connectors/table/jdbc.md
@@ -259,6 +259,18 @@ ON myTopic.key = MyUserTable.id;
       <td>查询数据库失败的最大重试次数。</td>
     </tr>
     <tr>
+      <td><h5>filter.handling.policy</h5></td>
+      <td>可选</td>
+      <td style="word-wrap: break-word;">always</td>
+      <td>枚举值，可选项: always, never</td>
+      <td>过滤器下推策略，支持的策略有:
+          <ul>
+            <li><code>always</code>: 始终将支持的过滤器下推到数据库.</li>
+            <li><code>never</code>: 不将任何过滤器下推到数据库.</li>
+          </ul>
+      </td>
+    </tr>
+    <tr>
       <td><h5>sink.buffer-flush.max-rows</h5></td>
       <td>可选</td>
       <td style="word-wrap: break-word;">100</td>

--- a/docs/content/docs/connectors/table/jdbc.md
+++ b/docs/content/docs/connectors/table/jdbc.md
@@ -275,6 +275,20 @@ Connector Options
       <td>The max retry times if lookup database failed.</td>
     </tr>
     <tr>
+      <td><h5>filter.handling.policy</h5></td>
+      <td>optional</td>
+      <td>no</td>
+      <td style="word-wrap: break-word;">always</td>
+      <td>Enum Possible values: always, never</td>
+      <td>Fine-grained configuration to control filter push down. 
+          Supported policies are:
+          <ul>
+            <li><code>always</code>: Always push the supported filters to database.</li>
+            <li><code>never</code>: Never push any filters to database.</li>
+          </ul>
+      </td>
+    </tr>
+    <tr>
       <td><h5>sink.buffer-flush.max-rows</h5></td>
       <td>optional</td>
       <td>yes</td>
@@ -305,7 +319,7 @@ Connector Options
       <td style="word-wrap: break-word;">(none)</td>
       <td>Integer</td>
       <td>Defines the parallelism of the JDBC sink operator. By default, the parallelism is determined by the framework using the same parallelism of the upstream chained operator.</td>
-    </tr>          
+    </tr>
     </tbody>
 </table>
 

--- a/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/table/FilterHandlingPolicy.java
+++ b/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/table/FilterHandlingPolicy.java
@@ -1,0 +1,33 @@
+package org.apache.flink.connector.jdbc.core.table;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.DescribedEnum;
+import org.apache.flink.configuration.description.InlineElement;
+
+import static org.apache.flink.configuration.description.TextElement.text;
+
+/** Fine-grained configuration to control filter push down for jdbc Table/SQL source. */
+@PublicEvolving
+public enum FilterHandlingPolicy implements DescribedEnum {
+    ALWAYS("always", text("Always push the supported filters to database.")),
+
+    NEVER("never", text("Never push any filters to database."));
+
+    private final String name;
+    private final InlineElement description;
+
+    FilterHandlingPolicy(String name, InlineElement description) {
+        this.name = name;
+        this.description = description;
+    }
+
+    @Override
+    public InlineElement getDescription() {
+        return description;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/table/JdbcConnectorOptions.java
+++ b/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/table/JdbcConnectorOptions.java
@@ -179,5 +179,12 @@ public class JdbcConnectorOptions {
                     .defaultValue(3)
                     .withDescription("The max retry times if writing records to database failed.");
 
+    public static final ConfigOption<FilterHandlingPolicy> FILTER_HANDLING_POLICY =
+            ConfigOptions.key("filter.handling.policy")
+                    .enumType(FilterHandlingPolicy.class)
+                    .defaultValue(FilterHandlingPolicy.ALWAYS)
+                    .withDescription(
+                            "Fine-grained configuration to control filter push down for jdbc Table/SQL source.");
+
     protected JdbcConnectorOptions() {}
 }

--- a/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/table/JdbcDynamicTableFactory.java
+++ b/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/table/JdbcDynamicTableFactory.java
@@ -54,6 +54,7 @@ import java.util.stream.Stream;
 
 import static org.apache.flink.connector.jdbc.core.table.JdbcConnectorOptions.COMPATIBLE_MODE;
 import static org.apache.flink.connector.jdbc.core.table.JdbcConnectorOptions.DRIVER;
+import static org.apache.flink.connector.jdbc.core.table.JdbcConnectorOptions.FILTER_HANDLING_POLICY;
 import static org.apache.flink.connector.jdbc.core.table.JdbcConnectorOptions.LOOKUP_CACHE_MAX_ROWS;
 import static org.apache.flink.connector.jdbc.core.table.JdbcConnectorOptions.LOOKUP_CACHE_MISSING_KEY;
 import static org.apache.flink.connector.jdbc.core.table.JdbcConnectorOptions.LOOKUP_CACHE_TTL;
@@ -128,6 +129,7 @@ public class JdbcDynamicTableFactory implements DynamicTableSourceFactory, Dynam
                 getJdbcReadOptions(helper.getOptions()),
                 helper.getOptions().get(LookupOptions.MAX_RETRIES),
                 getLookupCache(config),
+                helper.getOptions().get(FILTER_HANDLING_POLICY),
                 context.getPhysicalRowDataType());
     }
 
@@ -262,6 +264,7 @@ public class JdbcDynamicTableFactory implements DynamicTableSourceFactory, Dynam
         optionalOptions.add(LookupOptions.PARTIAL_CACHE_MAX_ROWS);
         optionalOptions.add(LookupOptions.PARTIAL_CACHE_CACHE_MISSING_KEY);
         optionalOptions.add(LookupOptions.MAX_RETRIES);
+        optionalOptions.add(FILTER_HANDLING_POLICY);
         return optionalOptions;
     }
 

--- a/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/table/JdbcDynamicTableFactoryTest.java
+++ b/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/table/JdbcDynamicTableFactoryTest.java
@@ -71,6 +71,7 @@ class JdbcDynamicTableFactoryTest {
         properties.put("username", "user");
         properties.put("password", "pass");
         properties.put("connection.max-retry-timeout", "120s");
+        properties.put("filter.handling.policy", "never");
 
         // validation for source
         DynamicTableSource actualSource = createTableSource(SCHEMA, properties);
@@ -89,6 +90,7 @@ class JdbcDynamicTableFactoryTest {
                         JdbcReadOptions.builder().build(),
                         LookupOptions.MAX_RETRIES.defaultValue(),
                         null,
+                        FilterHandlingPolicy.NEVER,
                         SCHEMA.toPhysicalRowDataType());
         assertThat(actualSource).isEqualTo(expectedSource);
 
@@ -146,6 +148,7 @@ class JdbcDynamicTableFactoryTest {
                         readOptions,
                         LookupOptions.MAX_RETRIES.defaultValue(),
                         null,
+                        JdbcConnectorOptions.FILTER_HANDLING_POLICY.defaultValue(),
                         SCHEMA.toPhysicalRowDataType());
 
         assertThat(actual).isEqualTo(expected);
@@ -174,6 +177,7 @@ class JdbcDynamicTableFactoryTest {
                         JdbcReadOptions.builder().build(),
                         10,
                         DefaultLookupCache.fromConfig(Configuration.fromMap(properties)),
+                        JdbcConnectorOptions.FILTER_HANDLING_POLICY.defaultValue(),
                         SCHEMA.toPhysicalRowDataType());
 
         assertThat(actual).isEqualTo(expected);
@@ -202,6 +206,7 @@ class JdbcDynamicTableFactoryTest {
                                 .maximumSize(1000L)
                                 .expireAfterWrite(Duration.ofSeconds(10))
                                 .build(),
+                        JdbcConnectorOptions.FILTER_HANDLING_POLICY.defaultValue(),
                         SCHEMA.toPhysicalRowDataType());
 
         assertThat(actual).isEqualTo(expected);
@@ -387,6 +392,7 @@ class JdbcDynamicTableFactoryTest {
                                 .maximumSize(1000L)
                                 .expireAfterWrite(Duration.ofSeconds(10))
                                 .build(),
+                        JdbcConnectorOptions.FILTER_HANDLING_POLICY.defaultValue(),
                         SCHEMA.toPhysicalRowDataType());
 
         assertThat(actual).isEqualTo(expected);

--- a/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/table/JdbcTablePlanTest.java
+++ b/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/table/JdbcTablePlanTest.java
@@ -54,6 +54,9 @@ class JdbcTablePlanTest extends TableTestBase {
                                 + ")");
         util.tableEnv()
                 .executeSql(
+                        "CREATE TABLE jdbc_never_pushdown WITH ('filter.handling.policy' = 'never') LIKE jdbc;");
+        util.tableEnv()
+                .executeSql(
                         "CREATE TABLE  d ( "
                                 + "ip varchar(20), type int, age int"
                                 + ") WITH ("
@@ -96,6 +99,12 @@ class JdbcTablePlanTest extends TableTestBase {
     void testFilterPushdown() {
         util.verifyExecPlan(
                 "SELECT id, time_col, real_col FROM jdbc WHERE id = 900001 AND time_col <> TIME '11:11:11' OR double_col >= -1000.23");
+    }
+
+    @Test
+    void testNeverFilterPushdown() {
+        util.verifyExecPlan(
+                "SELECT id, time_col, real_col FROM jdbc_never_pushdown WHERE id = 900001 AND time_col <> TIME '11:11:11' OR double_col >= -1000.23");
     }
 
     /**

--- a/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/table/source/JdbcDynamicTableSourceITCase.java
+++ b/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/table/source/JdbcDynamicTableSourceITCase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.connector.jdbc.core.table.source;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.jdbc.core.table.FilterHandlingPolicy;
 import org.apache.flink.connector.jdbc.testutils.DatabaseTest;
 import org.apache.flink.connector.jdbc.testutils.TableManaged;
 import org.apache.flink.connector.jdbc.testutils.tables.TableRow;
@@ -195,8 +196,9 @@ public abstract class JdbcDynamicTableSourceITCase implements DatabaseTest {
                 .containsAll(collected);
     }
 
-    @Test
-    public void testFilter() {
+    @ParameterizedTest
+    @EnumSource(FilterHandlingPolicy.class)
+    void testFilter(FilterHandlingPolicy filterHandlingPolicy) {
         String testTable = "testTable";
         tEnv.executeSql(inputTable.getCreateQueryForFlink(getMetadata(), testTable));
 
@@ -210,7 +212,8 @@ public abstract class JdbcDynamicTableSourceITCase implements DatabaseTest {
                                 "'scan.partition.column'='id'",
                                 "'scan.partition.num'='1'",
                                 "'scan.partition.lower-bound'='1'",
-                                "'scan.partition.upper-bound'='1'")));
+                                "'scan.partition.upper-bound'='1'",
+                                "'filter.handling.policy'='" + filterHandlingPolicy.name() + "'")));
 
         // we create a VIEW here to test column remapping, ie. would filter push down work if we
         // create a view that depends on our source table

--- a/flink-connector-jdbc-core/src/test/resources/org/apache/flink/connector/jdbc/core/table/JdbcTablePlanTest.xml
+++ b/flink-connector-jdbc-core/src/test/resources/org/apache/flink/connector/jdbc/core/table/JdbcTablePlanTest.xml
@@ -68,6 +68,24 @@ TableSourceScan(table=[[default_catalog, default_database, jdbc, filter=[and(OR(
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testNeverFilterPushdown">
+        <Resource name="sql">
+            <![CDATA[SELECT id, time_col, real_col FROM jdbc_never_pushdown WHERE id = 900001 AND time_col <> TIME '11:11:11' OR double_col >= -1000.23]]>
+        </Resource>
+        <Resource name="ast">
+            <![CDATA[
+LogicalProject(id=[$0], time_col=[$3], real_col=[$4])
++- LogicalFilter(condition=[OR(AND(=($0, 900001), <>($3, 11:11:11)), >=($5, -1000.23:DECIMAL(6, 2)))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, jdbc_never_pushdown]])
+]]>
+        </Resource>
+        <Resource name="optimized exec plan">
+            <![CDATA[
+Calc(select=[id, time_col, real_col], where=[(((id = 900001) OR (double_col >= -1000.23)) AND ((time_col <> 11:11:11) OR (double_col >= -1000.23)))])
++- TableSourceScan(table=[[default_catalog, default_database, jdbc_never_pushdown, filter=[], project=[id, time_col, real_col, double_col]]], fields=[id, time_col, real_col, double_col])
+]]>
+        </Resource>
+    </TestCase>
     <TestCase name="testLookupJoinWithANDAndORFilter">
         <Resource name="sql">
             <![CDATA[SELECT * FROM a LEFT JOIN d FOR SYSTEM_TIME AS OF a.proctime ON ((d.age = 50 AND d.type = 0) OR (d.type = 1 AND d.age = 40)) AND a.ip = d.ip]]>


### PR DESCRIPTION
This improvement implements [FLIP-377 Support fine-grained configuration to control filter push down for Table/SQL Sources](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=276105768)