### PR TITLE
[FLINK-34259] Fix fails to compile with NPE on hasGenericTypesDisabled

### DIFF
--- a/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/JdbcTestBase.java
+++ b/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/JdbcTestBase.java
@@ -59,9 +59,13 @@ public abstract class JdbcTestBase implements DerbyTestBase {
         return context;
     }
 
-    public static ExecutionConfig getExecutionConfig(Boolean reused) {
-        ExecutionConfig config = Mockito.mock(ExecutionConfig.class);
-        doReturn(reused).when(config).isObjectReuseEnabled();
+    public static ExecutionConfig getExecutionConfig(boolean reused) {
+        ExecutionConfig config = new ExecutionConfig();
+        if (reused) {
+            config.enableObjectReuse();
+        } else {
+            config.disableObjectReuse();
+        }
         return config;
     }
 


### PR DESCRIPTION
[FLINK-34259] Fix fails to compile with NPE on hasGenericTypesDisabled