### PR TITLE
[hotfix] Use 1.16.x as minimum supported version in pom

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -25,7 +25,7 @@ jobs:
   compile_and_test:
     strategy:
       matrix:
-        flink: [1.17-SNAPSHOT]
+        flink: [ 1.16-SNAPSHOT, 1.17-SNAPSHOT ]
         jdk: [ '8, 11' ]
         include:
           - flink: 1.18-SNAPSHOT

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@ under the License.
     </modules>
 
     <properties>
-        <flink.version>1.17.0</flink.version>
+        <flink.version>1.16.3</flink.version>
 
         <jackson-bom.version>2.13.4.20221013</jackson-bom.version>
         <junit4.version>4.13.2</junit4.version>


### PR DESCRIPTION
As it was identified at https://github.com/apache/flink-web/pull/707#discussion_r1472769071
there should be minimum Flink version in pom and in push pr as well