### PR TITLE
[hotfix] Use 1.16.0 as minimum supported Flink version in pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@ under the License.
     </modules>
 
     <properties>
-        <flink.version>1.16.2</flink.version>
+        <flink.version>1.16.0</flink.version>
 
         <jackson-bom.version>2.13.4.20221013</jackson-bom.version>
         <junit4.version>4.13.2</junit4.version>


### PR DESCRIPTION
This is a follow up task for comments at https://github.com/apache/flink-web/pull/707#discussion_r1495584009