### PR TITLE
[FLINK-35333] Remove weekly check for v3.1 with 1.19

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -45,10 +45,6 @@ jobs:
           flink: 1.18.0,
           jdk: '8, 11, 17',
           branch: v3.1
-        }, {
-          flink: 1.19.0,
-          jdk: '8, 11, 17, 21',
-          branch: v3.1
         }]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:


### PR DESCRIPTION
the branch cut for v3.1 was not prepared for 1.19 versions

in another PR we introduce this check, but I think that should be avoided as the cut is not prepared for that..

to prepare the branch to 1.19 we will have to bring some changes that are in master to solve some 1.19 problems