### PR TITLE
[FLINK-35542]  Set the correct class loader to lookup for the class CheckpointedOffset

### DIFF
--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/source/split/JdbcSourceSplitSerializer.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/source/split/JdbcSourceSplitSerializer.java
@@ -106,7 +106,8 @@ public class JdbcSourceSplitSerializer implements SimpleVersionedSerializer<Jdbc
         byte[] chkOffsetBytes = new byte[chkOffsetBytesLen];
         in.read(chkOffsetBytes);
         CheckpointedOffset chkOffset =
-                InstantiationUtil.deserializeObject(chkOffsetBytes, CheckpointedOffset.class.getClassLoader());
+                InstantiationUtil.deserializeObject(
+                        chkOffsetBytes, CheckpointedOffset.class.getClassLoader());
 
         return new JdbcSourceSplit(id, sqlTemplate, params, offset, chkOffset);
     }

--- a/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/source/split/JdbcSourceSplitSerializer.java
+++ b/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/source/split/JdbcSourceSplitSerializer.java
@@ -106,7 +106,7 @@ public class JdbcSourceSplitSerializer implements SimpleVersionedSerializer<Jdbc
         byte[] chkOffsetBytes = new byte[chkOffsetBytesLen];
         in.read(chkOffsetBytes);
         CheckpointedOffset chkOffset =
-                InstantiationUtil.deserializeObject(chkOffsetBytes, in.getClass().getClassLoader());
+                InstantiationUtil.deserializeObject(chkOffsetBytes, CheckpointedOffset.class.getClassLoader());
 
         return new JdbcSourceSplit(id, sqlTemplate, params, offset, chkOffset);
     }


### PR DESCRIPTION
- [FLINK-35542]  Use the class loader of class CheckpointedOffset while deserializing JdbcSourceSplit.