### PR TITLE
[hotfix] Remove redundant maven properties with upgrade of flink-connector-parent to 1.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,8 +73,6 @@ under the License.
         <log4j.version>2.17.2</log4j.version>
 
         <flink.parent.artifactId>flink-connector-jdbc-parent</flink.parent.artifactId>
-        <!-- These 2 properties should be removed together with upgrade of flink-connector-parent to 1.1.x -->
-        <flink.surefire.baseArgLine>-XX:+UseG1GC -Xms256m -XX:+IgnoreUnrecognizedVMOptions ${surefire.module.config}</flink.surefire.baseArgLine>
         <surefire.module.config>
             <!-- required by JdbcExactlyOnceSinkE2eTest --> --add-opens=java.base/java.util=ALL-UNNAMED
             <!-- SimpleJdbcConnectionProviderDriverClassConcurrentLoadingITCase--> --add-opens=java.base/java.lang=ALL-UNNAMED


### PR DESCRIPTION
Remove redundant maven properties with upgrade of flink-connector-parent to 1.1.0