### PR TITLE
Support reading json and jsonb types in PostgreSQL dialect

### DIFF
--- a/flink-connector-jdbc-postgres/src/main/java/org/apache/flink/connector/jdbc/postgres/database/catalog/PostgresTypeMapper.java
+++ b/flink-connector-jdbc-postgres/src/main/java/org/apache/flink/connector/jdbc/postgres/database/catalog/PostgresTypeMapper.java
@@ -84,6 +84,8 @@ public class PostgresTypeMapper implements JdbcCatalogTypeMapper {
     private static final String PG_CHARACTER_ARRAY = "_character";
     private static final String PG_CHARACTER_VARYING = "varchar";
     private static final String PG_CHARACTER_VARYING_ARRAY = "_varchar";
+    private static final String PG_JSON = "json";
+    private static final String PG_JSONB = "jsonb";
 
     @Override
     public DataType mapping(ObjectPath tablePath, ResultSetMetaData metadata, int colIndex)
@@ -157,6 +159,8 @@ public class PostgresTypeMapper implements JdbcCatalogTypeMapper {
             case PG_CHARACTER_VARYING_ARRAY:
                 return DataTypes.ARRAY(DataTypes.VARCHAR(precision));
             case PG_TEXT:
+            case PG_JSON:
+            case PG_JSONB:
                 return DataTypes.STRING();
             case PG_TEXT_ARRAY:
                 return DataTypes.ARRAY(DataTypes.STRING());


### PR DESCRIPTION
When using PostgreSQL JDBC Catalog an error is thrown if any of the tables has column of type `json` or `jsonb`.
```
java.lang.UnsupportedOperationException: Doesn't support Postgres type 'jsonb' yet
```

* `json` / `jsonb` field is returned as `VARCHAR` when reading the data.
* Writing values (`insert into ...`) to `json` / `jsonb` column is not allowed in current design.