### PR TITLE
[FLINK-36816] Support source parallelism setting for JDBC connector

### DIFF
--- a/docs/content.zh/docs/connectors/table/jdbc.md
+++ b/docs/content.zh/docs/connectors/table/jdbc.md
@@ -213,6 +213,14 @@ ON myTopic.key = MyUserTable.id;
       <a href="https://jdbc.postgresql.org/documentation/head/query.html#query-with-cursor">Postgres</a>，可能需要将此设置为 false 以便流化结果。</td>
     </tr>
     <tr>
+      <td><h5>scan.parallelism</h5></td>
+      <td>optional</td>
+      <td>no</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>Integer</td>
+      <td>定义 JDBC source 算子的并行度。默认情况下会使用全局默认并发。</td>
+    </tr>
+    <tr>
       <td><h5>lookup.cache</h5></td>
       <td>可选</td>
       <td style="word-wrap: break-word;">NONE</td>

--- a/docs/content/docs/connectors/table/jdbc.md
+++ b/docs/content/docs/connectors/table/jdbc.md
@@ -223,6 +223,14 @@ Connector Options
       <a href="https://jdbc.postgresql.org/documentation/head/query.html#query-with-cursor">Postgres</a>, may require this to be set to false in order to stream results.</td>
     </tr>
     <tr>
+      <td><h5>scan.parallelism</h5></td>
+      <td>optional</td>
+      <td>no</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>Integer</td>
+      <td>Defines the parallelism of the JDBC source operator. If not set, the global default parallelism is used.</td>
+    </tr>
+    <tr>
       <td><h5>lookup.cache</h5></td>
       <td>optional</td>
       <td>yes</td>

--- a/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/table/JdbcConnectorOptions.java
+++ b/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/table/JdbcConnectorOptions.java
@@ -80,6 +80,8 @@ public class JdbcConnectorOptions {
     // Scan options
     // -----------------------------------------------------------------------------------------
 
+    public static final ConfigOption<Integer> SCAN_PARALLELISM = FactoryUtil.SOURCE_PARALLELISM;
+
     public static final ConfigOption<String> SCAN_PARTITION_COLUMN =
             ConfigOptions.key("scan.partition.column")
                     .stringType()

--- a/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/table/JdbcDynamicTableFactory.java
+++ b/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/table/JdbcDynamicTableFactory.java
@@ -319,8 +319,7 @@ public class JdbcDynamicTableFactory implements DynamicTableSourceFactory, Dynam
             }
         }
 
-        if (config.getOptional(SCAN_PARALLELISM).isPresent()
-                && config.get(SCAN_PARALLELISM) <= 0) {
+        if (config.getOptional(SCAN_PARALLELISM).isPresent() && config.get(SCAN_PARALLELISM) <= 0) {
             throw new IllegalArgumentException(
                     String.format(
                             "The value of '%s' option should be positive, but is %s.",

--- a/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/table/source/JdbcDynamicTableSource.java
+++ b/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/table/source/JdbcDynamicTableSource.java
@@ -190,7 +190,7 @@ public class JdbcDynamicTableSource
         builder.setRowDataTypeInfo(
                 runtimeProviderContext.createTypeInformation(physicalRowDataType));
 
-        return InputFormatProvider.of(builder.build());
+        return InputFormatProvider.of(builder.build(), readOptions.getParallelism());
     }
 
     @Override

--- a/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/internal/options/JdbcReadOptions.java
+++ b/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/internal/options/JdbcReadOptions.java
@@ -33,6 +33,7 @@ public class JdbcReadOptions implements Serializable {
 
     private final int fetchSize;
     private final boolean autoCommit;
+    private final Integer parallelism;
 
     private JdbcReadOptions(
             String query,
@@ -41,7 +42,8 @@ public class JdbcReadOptions implements Serializable {
             Long partitionUpperBound,
             Integer numPartitions,
             int fetchSize,
-            boolean autoCommit) {
+            boolean autoCommit,
+            Integer parallelism) {
         this.query = query;
         this.partitionColumnName = partitionColumnName;
         this.partitionLowerBound = partitionLowerBound;
@@ -50,6 +52,7 @@ public class JdbcReadOptions implements Serializable {
 
         this.fetchSize = fetchSize;
         this.autoCommit = autoCommit;
+        this.parallelism = parallelism;
     }
 
     public Optional<String> getQuery() {
@@ -80,6 +83,10 @@ public class JdbcReadOptions implements Serializable {
         return autoCommit;
     }
 
+    public Integer getParallelism() {
+        return parallelism;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -94,7 +101,8 @@ public class JdbcReadOptions implements Serializable {
                     && Objects.equals(partitionUpperBound, options.partitionUpperBound)
                     && Objects.equals(numPartitions, options.numPartitions)
                     && Objects.equals(fetchSize, options.fetchSize)
-                    && Objects.equals(autoCommit, options.autoCommit);
+                    && Objects.equals(autoCommit, options.autoCommit)
+                    && Objects.equals(parallelism, options.parallelism);
         } else {
             return false;
         }
@@ -110,6 +118,7 @@ public class JdbcReadOptions implements Serializable {
 
         protected int fetchSize = 0;
         protected boolean autoCommit = true;
+        protected Integer scanParallelism;
 
         /** optional, SQL query statement for this JDBC source. */
         public Builder setQuery(String query) {
@@ -159,6 +168,12 @@ public class JdbcReadOptions implements Serializable {
             return this;
         }
 
+        /** optional, source scan parallelism. */
+        public Builder setParallelism(int scanParallelism) {
+            this.scanParallelism = scanParallelism;
+            return this;
+        }
+
         public JdbcReadOptions build() {
             return new JdbcReadOptions(
                     query,
@@ -167,7 +182,8 @@ public class JdbcReadOptions implements Serializable {
                     partitionUpperBound,
                     numPartitions,
                     fetchSize,
-                    autoCommit);
+                    autoCommit,
+                    scanParallelism);
         }
     }
 }

--- a/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/table/JdbcDynamicTableFactoryTest.java
+++ b/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/table/JdbcDynamicTableFactoryTest.java
@@ -125,6 +125,7 @@ class JdbcDynamicTableFactoryTest {
         properties.put("scan.partition.num", "10");
         properties.put("scan.fetch-size", "20");
         properties.put("scan.auto-commit", "false");
+        properties.put("scan.parallelism", "13");
 
         DynamicTableSource actual = createTableSource(SCHEMA, properties);
 
@@ -141,6 +142,7 @@ class JdbcDynamicTableFactoryTest {
                         .setNumPartitions(10)
                         .setFetchSize(20)
                         .setAutoCommit(false)
+                        .setParallelism(13)
                         .build();
         JdbcDynamicTableSource expected =
                 new JdbcDynamicTableSource(
@@ -366,6 +368,16 @@ class JdbcDynamicTableFactoryTest {
         assertThatThrownBy(() -> createTableSource(SCHEMA, finalProperties7))
                 .hasStackTraceContaining(
                         "The value of 'connection.max-retry-timeout' option must be in second granularity and shouldn't be smaller than 1 second, but is 100ms.");
+
+        // scan parallelism > = 1
+        properties = getAllOptions();
+        properties.put("scan.parallelism", "-1");
+
+        Map<String, String> finalProperties8 = properties;
+        assertThatThrownBy(() -> createTableSource(SCHEMA, finalProperties8))
+                .hasStackTraceContaining(
+                        "The value of 'scan.parallelism' option should be positive, but is -1.");
+
     }
 
     @Test

--- a/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/table/JdbcDynamicTableFactoryTest.java
+++ b/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/table/JdbcDynamicTableFactoryTest.java
@@ -372,12 +372,10 @@ class JdbcDynamicTableFactoryTest {
         // scan parallelism > = 1
         properties = getAllOptions();
         properties.put("scan.parallelism", "-1");
-
         Map<String, String> finalProperties8 = properties;
         assertThatThrownBy(() -> createTableSource(SCHEMA, finalProperties8))
                 .hasStackTraceContaining(
                         "The value of 'scan.parallelism' option should be positive, but is -1.");
-
     }
 
     @Test


### PR DESCRIPTION
# Purpose of the change

Add new option `scan.parallelism` support for JDBC connector.

Part of [FLINK-33261](https://issues.apache.org/jira/browse/FLINK-33261) FLIP-367: Support Setting Parallelism for Table/SQL Sources

The change is not backward compatible for versions <= 1.18. `InputFormatProvider of(InputFormat<RowData, ?> inputFormat, @Nullable Integer sourceParallelism)` was added in Flink 1.19. Therefore, we need to wait with this change until JDBC connector is no longer supporting Flink 1.18.


