### PR TITLE
[FLINK-36236] JdbcSourceBuilder overrides set connection provider

### DIFF
--- a/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/source/JdbcSourceBuilder.java
+++ b/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/source/JdbcSourceBuilder.java
@@ -267,7 +267,10 @@ public class JdbcSourceBuilder<OUT> {
     }
 
     public JdbcSource<OUT> build() {
-        this.connectionProvider = new SimpleJdbcConnectionProvider(connOptionsBuilder.build());
+        if (Objects.isNull(this.connectionProvider)) {
+            this.connectionProvider = new SimpleJdbcConnectionProvider(connOptionsBuilder.build());
+        }
+
         if (resultSetFetchSize > 0) {
             this.configuration.set(JdbcSourceOptions.RESULTSET_FETCH_SIZE, resultSetFetchSize);
         }


### PR DESCRIPTION
Only instantiate the provider from the connection options builder if no provider was set on the builder