### PR TITLE
[hotfix][Connector/JDBC] Remove unnecessary unique fields of PostgreSQL upsert statement

### DIFF
--- a/flink-connector-jdbc-postgres/src/test/java/org/apache/flink/connector/jdbc/postgres/database/dialect/PostgresDialectTest.java
+++ b/flink-connector-jdbc-postgres/src/test/java/org/apache/flink/connector/jdbc/postgres/database/dialect/PostgresDialectTest.java
@@ -21,8 +21,12 @@ package org.apache.flink.connector.jdbc.postgres.database.dialect;
 import org.apache.flink.connector.jdbc.core.database.dialect.JdbcDialectTest;
 import org.apache.flink.connector.jdbc.postgres.PostgresTestBase;
 
+import org.junit.jupiter.api.Test;
+
 import java.util.Arrays;
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** The PostgresSql params for {@link JdbcDialectTest}. */
 class PostgresDialectTest extends JdbcDialectTest implements PostgresTestBase {
@@ -57,5 +61,25 @@ class PostgresDialectTest extends JdbcDialectTest implements PostgresTestBase {
                         "TIMESTAMP(9) WITHOUT TIME ZONE",
                         "The precision of field 'f0' is out of the TIMESTAMP precision range [1, 6] supported by PostgreSQL dialect."),
                 createTestItem("TIMESTAMP_LTZ(3)", "Unsupported type:TIMESTAMP_LTZ(3)"));
+    }
+
+    @Test
+    void testUpsertStatement() {
+        PostgresDialect dialect = new PostgresDialect();
+        final String tableName = "tbl";
+        final String[] fieldNames = {
+            "id", "name", "email", "ts", "field1", "field_2", "__field_3__"
+        };
+        final String[] doUpdatekeyFields = {"id", "__field_3__"};
+        final String[] doNothingkeyFields = {
+            "id", "name", "email", "ts", "field1", "field_2", "__field_3__"
+        };
+
+        assertThat(dialect.getUpsertStatement(tableName, fieldNames, doUpdatekeyFields).get())
+                .isEqualTo(
+                        "INSERT INTO tbl(id, name, email, ts, field1, field_2, __field_3__) VALUES (:id, :name, :email, :ts, :field1, :field_2, :__field_3__) ON CONFLICT (id, __field_3__) DO UPDATE SET name=EXCLUDED.name, email=EXCLUDED.email, ts=EXCLUDED.ts, field1=EXCLUDED.field1, field_2=EXCLUDED.field_2");
+        assertThat(dialect.getUpsertStatement(tableName, fieldNames, doNothingkeyFields).get())
+                .isEqualTo(
+                        "INSERT INTO tbl(id, name, email, ts, field1, field_2, __field_3__) VALUES (:id, :name, :email, :ts, :field1, :field_2, :__field_3__) ON CONFLICT (id, name, email, ts, field1, field_2, __field_3__) DO NOTHING");
     }
 }


### PR DESCRIPTION
In PostgreSQL, there is no need to specify the unique key fields in the `DO UPDATE SET` clause.

See more details in https://www.postgresql.org/docs/current/sql-insert.html