### PR TITLE
FLINK-36236 Fix overriding the connection provider in JdbcSourceBuilder

### DIFF
--- a/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/source/JdbcSource.java
+++ b/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/source/JdbcSource.java
@@ -162,18 +162,23 @@ public class JdbcSource<OUT>
     }
 
     @VisibleForTesting
-    public TypeInformation<OUT> getTypeInformation() {
+    TypeInformation<OUT> getTypeInformation() {
         return typeInformation;
     }
 
     @VisibleForTesting
-    public Configuration getConfiguration() {
+    Configuration getConfiguration() {
         return configuration;
     }
 
     @VisibleForTesting
-    public ResultExtractor<OUT> getResultExtractor() {
+    ResultExtractor<OUT> getResultExtractor() {
         return resultExtractor;
+    }
+
+    @VisibleForTesting
+    JdbcConnectionProvider getConnectionProvider() {
+        return connectionProvider;
     }
 
     @VisibleForTesting

--- a/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/source/JdbcSourceBuilder.java
+++ b/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/source/JdbcSourceBuilder.java
@@ -267,7 +267,10 @@ public class JdbcSourceBuilder<OUT> {
     }
 
     public JdbcSource<OUT> build() {
-        this.connectionProvider = new SimpleJdbcConnectionProvider(connOptionsBuilder.build());
+        if(this.connectionProvider == null) {
+            this.connectionProvider = new SimpleJdbcConnectionProvider(connOptionsBuilder.build());
+        }
+
         if (resultSetFetchSize > 0) {
             this.configuration.set(JdbcSourceOptions.RESULTSET_FETCH_SIZE, resultSetFetchSize);
         }

--- a/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/datastream/source/JdbcSourceBuilderTest.java
+++ b/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/datastream/source/JdbcSourceBuilderTest.java
@@ -20,9 +20,12 @@ package org.apache.flink.connector.jdbc.core.datastream.source;
 
 import org.apache.flink.api.common.typeinfo.TypeHint;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.connector.jdbc.JdbcConnectionOptions;
 import org.apache.flink.connector.jdbc.core.datastream.source.config.ContinuousUnBoundingSettings;
 import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.SqlTemplateSplitEnumerator;
 import org.apache.flink.connector.jdbc.core.datastream.source.reader.extractor.ResultExtractor;
+import org.apache.flink.connector.jdbc.datasource.connections.JdbcConnectionProvider;
+import org.apache.flink.connector.jdbc.datasource.connections.SimpleJdbcConnectionProvider;
 import org.apache.flink.connector.jdbc.split.JdbcGenericParameterValuesProvider;
 import org.apache.flink.connector.jdbc.split.JdbcNumericBetweenParametersProvider;
 import org.apache.flink.connector.jdbc.split.JdbcParameterValuesProvider;
@@ -180,5 +183,23 @@ class JdbcSourceBuilderTest {
                                         .build())
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage(JdbcSourceBuilder.INVALID_CONTINUOUS_SLIDE_TIMING_HINT);
+    }
+
+    @Test
+    void testSetConnectionProvider() {
+        assertThatThrownBy(() -> JdbcSource.builder().setConnectionProvider(null))
+            .isInstanceOf(NullPointerException.class);
+
+        final JdbcConnectionOptions options =
+            new JdbcConnectionOptions.JdbcConnectionOptionsBuilder()
+                .withUrl(dbUrl)
+                .withDriverName(driverName)
+                .build();
+
+        final JdbcConnectionProvider connectionProvider = new SimpleJdbcConnectionProvider(options);
+
+        JdbcSource<Row> jdbcSource = sourceBuilder.setConnectionProvider(connectionProvider).build();
+
+        assertThat(jdbcSource.getConnectionProvider()).isSameAs(connectionProvider);
     }
 }


### PR DESCRIPTION
### FLINK-36236: Fix Overriding the Connection Provider in `JdbcSourceBuilder`

#### Summary

This PR fixes an issue where a custom `JdbcConnectionProvider` passed via `JdbcSourceBuilder#setConnectionProvider` was unintentionally overwritten during the `build()` process. This prevented users from injecting their own connection management logic (e.g., for testing or advanced connection pooling scenarios).

#### Changes

- **`JdbcSourceBuilder`**
  - Modified `build()` method to only set a default `SimpleJdbcConnectionProvider` **if** no custom provider has been set.
  
- **`JdbcSource`**
  - Exposed a `getConnectionProvider()` method with `@VisibleForTesting` to enable access from test code.

- **Test Coverage**
  - Added a unit test `testSetConnectionProvider()` to:
    - Verify that `null` values are rejected.
    - Assert that the `JdbcSource` retains and uses the explicitly provided `JdbcConnectionProvider`.

#### Motivation

This change ensures the builder pattern behaves predictably: user-provided values should not be silently overridden. This is especially important when dependency injection or custom behavior is expected during source initialization.