### PR TITLE
[FLINK-36303] PostgreSQL timestamp precision 0 not supported

### DIFF
--- a/flink-connector-jdbc-cratedb/src/test/java/org/apache/flink/connector/jdbc/cratedb/database/dialect/CrateDBDialectTest.java
+++ b/flink-connector-jdbc-cratedb/src/test/java/org/apache/flink/connector/jdbc/cratedb/database/dialect/CrateDBDialectTest.java
@@ -51,7 +51,7 @@ class CrateDBDialectTest extends JdbcDialectTest implements CrateDBTestBase {
                 createTestItem("BINARY", "The CrateDB dialect doesn't support type: BINARY(1)."),
                 createTestItem(
                         "TIMESTAMP(9) WITHOUT TIME ZONE",
-                        "The precision of field 'f0' is out of the TIMESTAMP precision range [1, 6] supported by CrateDB dialect."),
+                        "The precision of field 'f0' is out of the TIMESTAMP precision range [0, 6] supported by CrateDB dialect."),
                 createTestItem("TIMESTAMP_LTZ(3)", "Unsupported type:TIMESTAMP_LTZ(3)"));
     }
 }

--- a/flink-connector-jdbc-postgres/src/test/java/org/apache/flink/connector/jdbc/postgres/database/dialect/PostgresDialectTest.java
+++ b/flink-connector-jdbc-postgres/src/test/java/org/apache/flink/connector/jdbc/postgres/database/dialect/PostgresDialectTest.java
@@ -59,7 +59,7 @@ class PostgresDialectTest extends JdbcDialectTest implements PostgresTestBase {
                         "The PostgreSQL dialect doesn't support type: VARBINARY(10)."),
                 createTestItem(
                         "TIMESTAMP(9) WITHOUT TIME ZONE",
-                        "The precision of field 'f0' is out of the TIMESTAMP precision range [1, 6] supported by PostgreSQL dialect."),
+                        "The precision of field 'f0' is out of the TIMESTAMP precision range [0, 6] supported by PostgreSQL dialect."),
                 createTestItem("TIMESTAMP_LTZ(3)", "Unsupported type:TIMESTAMP_LTZ(3)"));
     }
 


### PR DESCRIPTION
This is a followup to #142 to make the integration test match the original code change.