### PR TITLE
[FLINK-38046][Connector/JDBC]Solve the issue of missing one piece of data

### DIFF
--- a/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/split/JdbcNumericBetweenParametersProvider.java
+++ b/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/split/JdbcNumericBetweenParametersProvider.java
@@ -111,7 +111,6 @@ public class JdbcNumericBetweenParametersProvider implements JdbcParameterValues
             parameters[i] = new Long[] {start, end};
             start = end + 1;
         }
-
         parameters[batchNum - 1] = new Long[] {start, maxVal};
         return parameters;
     }

--- a/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/split/JdbcNumericBetweenParametersProvider.java
+++ b/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/split/JdbcNumericBetweenParametersProvider.java
@@ -98,8 +98,8 @@ public class JdbcNumericBetweenParametersProvider implements JdbcParameterValues
     @Override
     public Serializable[][] getParameterValues() {
         Preconditions.checkState(
-            batchSize > 0,
-            "Batch size and batch number must be positive. Have you called `ofBatchSize` or `ofBatchNum`?");
+                batchSize > 0,
+                "Batch size and batch number must be positive. Have you called `ofBatchSize` or `ofBatchNum`?");
 
         long maxElemCount = (maxVal - minVal) + 1;
         long bigBatchNum = maxElemCount - (batchSize - 1) * batchNum;

--- a/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/split/JdbcNumericBetweenParametersProvider.java
+++ b/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/split/JdbcNumericBetweenParametersProvider.java
@@ -98,19 +98,21 @@ public class JdbcNumericBetweenParametersProvider implements JdbcParameterValues
     @Override
     public Serializable[][] getParameterValues() {
         Preconditions.checkState(
-                batchSize > 0,
-                "Batch size and batch number must be positive. Have you called `ofBatchSize` or `ofBatchNum`?");
+            batchSize > 0,
+            "Batch size and batch number must be positive. Have you called `ofBatchSize` or `ofBatchNum`?");
 
         long maxElemCount = (maxVal - minVal) + 1;
         long bigBatchNum = maxElemCount - (batchSize - 1) * batchNum;
 
         Serializable[][] parameters = new Serializable[batchNum][2];
         long start = minVal;
-        for (int i = 0; i < batchNum; i++) {
+        for (int i = 0; i < batchNum - 1; i++) {
             long end = start + batchSize - 1 - (i >= bigBatchNum ? 1 : 0);
             parameters[i] = new Long[] {start, end};
             start = end + 1;
         }
+
+        parameters[batchNum - 1] = new Long[] {start, maxVal};
         return parameters;
     }
 

--- a/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/split/NumericBetweenParametersProviderTest.java
+++ b/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/split/NumericBetweenParametersProviderTest.java
@@ -115,6 +115,21 @@ class NumericBetweenParametersProviderTest {
         check(expected, actual);
     }
 
+    @Test
+    void testBatchMaxMinTooLarge() {
+        JdbcNumericBetweenParametersProvider provider =
+                new JdbcNumericBetweenParametersProvider(2260418954055131340L, 3875220057236942850L)
+                        .ofBatchSize(3);
+        Serializable[][] actual = provider.getParameterValues();
+
+        long[][] expected = {
+            new long[] {2260418954055131340L, 2798685988449068510L},
+            new long[] {2798685988449068511L, 3336953022843005681L},
+            new long[] {3336953022843005682L, 3875220057236942850L}
+        };
+        check(expected, actual);
+    }
+
     private void check(long[][] expected, Serializable[][] actual) {
         assertThat(actual).hasDimensions(expected.length, expected[0].length);
         for (int i = 0; i < expected.length; i++) {


### PR DESCRIPTION
When using partitioned scan in Flink JDBC table, if scan.partition.lower-bound and scan.partition.upper-bound are very large, there could be a situation where one data record is lost. For example, maximum value: 3875220057236942850, minimum value: 2260418954055131340.