### PR TITLE
[hotfix] Stabilize integration test (derby)

### DIFF
--- a/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/source/reader/JdbcSourceSplitReader.java
+++ b/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/source/reader/JdbcSourceSplitReader.java
@@ -145,10 +145,16 @@ public class JdbcSourceSplitReader<T>
                 batch--;
                 // Check if ResultSet is still open before calling next()
                 // This is needed for databases like Derby where ResultSet might be closed
-                // when autocommit is disabled
-                if (!resultSet.isClosed()) {
-                    hasNextRecordCurrentSplit = resultSet.next();
-                } else {
+                // when autocommit is disabled. Also handles PostgreSQL where isClosed()
+                // throws exception if connection is closed.
+                try {
+                    if (!resultSet.isClosed()) {
+                        hasNextRecordCurrentSplit = resultSet.next();
+                    } else {
+                        hasNextRecordCurrentSplit = false;
+                    }
+                } catch (SQLException sqlEx) {
+                    // ResultSet or connection is closed - treat as no more records
                     hasNextRecordCurrentSplit = false;
                 }
             } catch (Exception e) {

--- a/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/source/reader/JdbcSourceSplitReader.java
+++ b/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/source/reader/JdbcSourceSplitReader.java
@@ -143,7 +143,14 @@ public class JdbcSourceSplitReader<T>
                 recordAndOffsetBuilder.add(
                         currentSplit, new RecordAndOffset<>(record, ++currentSplitOffset, 0));
                 batch--;
-                hasNextRecordCurrentSplit = resultSet.next();
+                // Check if ResultSet is still open before calling next()
+                // This is needed for databases like Derby where ResultSet might be closed
+                // when autocommit is disabled
+                if (!resultSet.isClosed()) {
+                    hasNextRecordCurrentSplit = resultSet.next();
+                } else {
+                    hasNextRecordCurrentSplit = false;
+                }
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/source/reader/JdbcSourceSplitReader.java
+++ b/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/source/reader/JdbcSourceSplitReader.java
@@ -139,14 +139,27 @@ public class JdbcSourceSplitReader<T>
         int batch = this.splitReaderFetchBatchSize;
         while (batch > 0 && hasNextRecordCurrentSplit) {
             try {
+                // Check if ResultSet is still open before extracting data
+                // This is needed for databases like Derby where ResultSet might be closed
+                // when autocommit is disabled. Also handles PostgreSQL where isClosed()
+                // throws exception if connection is closed.
+                try {
+                    if (resultSet.isClosed()) {
+                        hasNextRecordCurrentSplit = false;
+                        break;
+                    }
+                } catch (SQLException sqlEx) {
+                    // ResultSet or connection is closed - treat as no more records
+                    hasNextRecordCurrentSplit = false;
+                    break;
+                }
+
                 T record = resultExtractor.extract(resultSet);
                 recordAndOffsetBuilder.add(
                         currentSplit, new RecordAndOffset<>(record, ++currentSplitOffset, 0));
                 batch--;
+
                 // Check if ResultSet is still open before calling next()
-                // This is needed for databases like Derby where ResultSet might be closed
-                // when autocommit is disabled. Also handles PostgreSQL where isClosed()
-                // throws exception if connection is closed.
                 try {
                     if (!resultSet.isClosed()) {
                         hasNextRecordCurrentSplit = resultSet.next();


### PR DESCRIPTION
## Summary

Fix `DerbyDynamicTableSourceITCase.testLimit` failure caused by ResultSet being closed when autocommit is disabled.

## Changes

- Add `resultSet.isClosed()` check before calling `next()` in `JdbcSourceSplitReader`

## Test

```bash
mvn test -Dtest=DerbyDynamicTableSourceITCase -pl flink-connector-jdbc-core
```