### PR TITLE
[FLINK-38046][Connector/JDBC] Solve the issue of missing one piece of data

### DIFF
--- a/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/split/JdbcNumericBetweenParametersProvider.java
+++ b/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/split/JdbcNumericBetweenParametersProvider.java
@@ -112,11 +112,12 @@ public class JdbcNumericBetweenParametersProvider implements JdbcParameterValues
 
         Serializable[][] parameters = new Serializable[batchNum][2];
         long start = minVal;
-        for (int i = 0; i < batchNum; i++) {
+        for (int i = 0; i < batchNum - 1; i++) {
             long end = start + batchSize - 1 - (i >= bigBatchNum ? 1 : 0);
             parameters[i] = new Long[] {start, end};
             start = end + 1;
         }
+        parameters[batchNum - 1] = new Long[] {start, maxVal};
         return parameters;
     }
 

--- a/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/split/NumericBetweenParametersProviderTest.java
+++ b/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/split/NumericBetweenParametersProviderTest.java
@@ -115,6 +115,21 @@ class NumericBetweenParametersProviderTest {
         check(expected, actual);
     }
 
+    @Test
+    void testBatchMaxMinTooLarge() {
+        JdbcNumericBetweenParametersProvider provider =
+                new JdbcNumericBetweenParametersProvider(2260418954055131340L, 3875220057236942850L)
+                        .ofBatchNum(3);
+        Serializable[][] actual = provider.getParameterValues();
+
+        long[][] expected = {
+            new long[] {2260418954055131340L, 2798685988449068491L},
+            new long[] {2798685988449068492L, 3336953022843005643L},
+            new long[] {3336953022843005644L, 3875220057236942850L}
+        };
+        check(expected, actual);
+    }
+
     private void check(long[][] expected, Serializable[][] actual) {
         assertThat(actual).hasDimensions(expected.length, expected[0].length);
         for (int i = 0; i < expected.length; i++) {


### PR DESCRIPTION
# What is the purpose of the change

When using partitioned scan in Flink JDBC, if scan.partition.lower-bound and scan.partition.upper-bound are very large values (near Long range), integer arithmetic overflow causes the last partition to be silently dropped, resulting in one batch of data being lost.

This fix was originally identified and implemented by @wangxiaojing in #174. Since the PR had been inactive for an extended period with no release progress, I am resubmitting it to move things forward. All credit for the investigation and fix goes to @wangxiaojing.

# Brief change log

- JdbcNumericBetweenParametersProvider.getParameterValues(): changed the loop to iterate batchNum - 1 times and explicitly set the last partition's upper bound to maxVal
- Added regression test testBatchMaxMinTooLarge covering the overflow scenario with large Long values


# Verifying this change

- Run NumericBetweenParametersProviderTest#testBatchMaxMinTooLarge which covers the exact overflow case (lower=2260418954055131340, upper=3875220057236942850, batchNum=3)
- All 7 existing tests in NumericBetweenParametersProviderTest pass