### PR TITLE
[hotfix][JDBC] Fix db2 Db2Dialect error.

### DIFF
--- a/flink-connector-jdbc-db2/src/main/java/org/apache/flink/connector/jdbc/db2/database/dialect/Db2Dialect.java
+++ b/flink-connector-jdbc-db2/src/main/java/org/apache/flink/connector/jdbc/db2/database/dialect/Db2Dialect.java
@@ -111,7 +111,7 @@ public class Db2Dialect extends AbstractDialect {
                                         + " WHEN MATCHED THEN"
                                         + " UPDATE SET %s"
                                         + " WHEN NOT MATCHED THEN"
-                                        + " INSERT (%s) VALUES (%s);",
+                                        + " INSERT (%s) VALUES (%s)",
                                 quoteIdentifier(tableName),
                                 valuesBinding,
                                 columnBinding,

--- a/flink-connector-jdbc-db2/src/test/java/org/apache/flink/connector/jdbc/db2/database/dialect/Db2PreparedStatementTest.java
+++ b/flink-connector-jdbc-db2/src/test/java/org/apache/flink/connector/jdbc/db2/database/dialect/Db2PreparedStatementTest.java
@@ -74,7 +74,8 @@ class Db2PreparedStatementTest {
         String upsertStmt = dialect.getUpsertStatement(tableName, fieldNames, keyFields).get();
         assertThat(upsertStmt)
                 .isEqualTo(
-                        "MERGE INTO tbl AS TARGET USING TABLE (VALUES ( :id, :name, :email, :ts, :field1, :field_2, :__field_3__ )) AS SOURCE ( id, name, email, ts, field1, field_2, __field_3__ ) ON (TARGET.id= SOURCE.id AND TARGET.__field_3__= SOURCE.__field_3__) WHEN MATCHED THEN UPDATE SET TARGET.name= SOURCE.name, TARGET.email= SOURCE.email, TARGET.ts= SOURCE.ts, TARGET.field1= SOURCE.field1, TARGET.field_2= SOURCE.field_2 WHEN NOT MATCHED THEN INSERT (id, name, email, ts, field1, field_2, __field_3__) VALUES (SOURCE.id, SOURCE.name, SOURCE.email, SOURCE.ts, SOURCE.field1, SOURCE.field_2, SOURCE.__field_3__);");
+                        "MERGE INTO tbl AS TARGET USING TABLE (VALUES ( :id, :name, :email, :ts, :field1, :field_2, :__field_3__ )) AS SOURCE ( id, name, email, ts, field1, field_2, __field_3__ ) ON (TARGET.id= SOURCE.id AND TARGET.__field_3__= SOURCE.__field_3__) WHEN MATCHED THEN UPDATE SET TARGET.name= SOURCE.name, TARGET.email= SOURCE.email, TARGET.ts= SOURCE.ts, TARGET.field1= SOURCE.field1, TARGET.field_2= SOURCE.field_2 WHEN NOT MATCHED THEN INSERT (id, name, email, ts, field1, field_2, __field_3__) VALUES (SOURCE.id, SOURCE.name, SOURCE.email, SOURCE.ts, SOURCE.field1, SOURCE.field_2, SOURCE.__field_3__)")
+                .doesNotEndWith(";");
     }
 
     @Test


### PR DESCRIPTION
Removed the semicolon from the SQL query as it caused a syntax error . ( Caused by: com.ibm.db2.jcc.am.SqlSyntaxErrorException: DB2 SQL Error: SQLCODE=-104, SQLSTATE=42601, SQLERRMC=;;columnA, SOURCE.columnB);END-OF-STATEMENT, DRIVER=4.26.14 )


Take over it from https://github.com/apache/flink-connector-jdbc/pull/151 and keep the original author signutrue