### PR TITLE
[FLINK-40060][Connectors/JDBC] Remove redundant org.postgresql dependency in flink-connector-jdbc-backward-compatibility

### DIFF
--- a/flink-connector-jdbc-backward-compatibility/pom.xml
+++ b/flink-connector-jdbc-backward-compatibility/pom.xml
@@ -89,12 +89,6 @@
             <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.postgresql</groupId>
-            <artifactId>postgresql</artifactId>
-            <version>42.7.3</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
## What is the purpose of the change

`flink-connector-jdbc-backward-compatibility/pom.xml` declares the
`org.postgresql:postgresql` test dependency twice:

- once using the `${postgres.version}` property
- once hardcoded as `42.7.3`

Since `${postgres.version}` already resolves to `42.7.3`, the two
declarations are identical and the hardcoded one is redundant.

## Brief change log

- Removed the duplicate `org.postgresql:postgresql` dependency that
  hardcoded the version as `42.7.3`, keeping only the declaration that
  uses the `${postgres.version}` property.

## Verifying this change

This is a test-scope dependency cleanup with no production code
impact. Existing tests should continue to pass unchanged since the
remaining dependency resolves to the same version.

## Does this pull request potentially affect one of the following parts

  - Dependencies (test scope only): yes
  - The public API, i.e., is any changed class annotated with
    `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths: no
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable