### PR TITLE
[FLINK-40061][Connectors/JDBC] Update parent version and flink.version in flink-connector-jdbc pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-connector-parent</artifactId>
-        <version>1.1.0</version>
+        <version>2.0.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -56,7 +56,7 @@ under the License.
     </modules>
 
     <properties>
-        <flink.version>2.0.0</flink.version>
+        <flink.version>2.1.0</flink.version>
         <scala.binary.version>2.12</scala.binary.version>
         <scala-library.version>2.12.7</scala-library.version>
         <jackson-bom.version>2.13.4.20221013</jackson-bom.version>


### PR DESCRIPTION
## What is the purpose of the change

Update `flink-connector-jdbc`'s pom.xml to align with the latest
parent artifact and Flink core version:

- `flink-connector-parent` version bumped from `1.1.0` to `2.0.0`
- `flink.version` property bumped from `2.0.0` to `2.1.0`

These bumps keep the connector aligned with the latest
flink-connector-parent and Flink core releases.

## Brief change log

- Updated `flink-connector-parent` version: `1.1.0` -> `2.0.0`
- Updated `flink.version` property: `2.0.0` -> `2.1.0`

## Verifying this change

This change updates the parent POM and Flink core version references
only; no source code changes are involved. Existing build and test
suite should be run against the updated parent/Flink versions to
confirm compatibility.

## Does this pull request potentially affect one of the following parts

  - Dependencies (parent POM and Flink core version): yes
  - The public API, i.e., is any changed class annotated with
    `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths: no
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable