### PR TITLE
[hotfix][Connectors/JDBC] Bump Flink test version to 1.20.5 to fix CI binary download

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -28,7 +28,7 @@ jobs:
   compile_and_test:
     strategy:
       matrix:
-        flink: [1.20.0]
+        flink: [1.20.5]
         jdk: [ '8, 11, 17, 21' ]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:


### PR DESCRIPTION
## What is the purpose of the change

Unblocks the JDBC connector v3.4.0 release. CI on the `v3.4` branch fails at the "Download Flink binary" step because the pinned test version `1.20.0` was removed from `dlcdn.apache.org` after newer `1.20.x` patches shipped. `wget -q … -O - | tar -xz` then receives a 404 body and fails with `gzip: stdin: unexpected end of file` (exit code 2).

## Brief change log

- Bump the Flink test version in `.github/workflows/push_pr.yml` from `1.20.0` to `1.20.5`, the current `1.20.x` patch still available on the mirror.

## Verifying this change

Validated on a fork before opening this PR: the full `push_pr.yml` matrix (JDK 8/11/17/21) is green against Flink 1.20.5, including the previously-failing "Download Flink binary" step.
Run: https://github.com/weiqingy/flink-connector-jdbc/actions/runs/28815887503

Note: `weekly.yml` on this branch still pins `1.19.1` and `1.18.0`, which are likewise no longer on the mirror. Left out here to keep this change surgical for the release; can be addressed as a separate follow-up.

## Does this pull request potentially affect one of the following parts

- Dependencies (does it add or upgrade a dependency): **no** (CI test version only)
- The public API: **no**
- The serializers: **no**
- The runtime per-record code paths: **no**

## Documentation

- Does this pull request introduce a new feature? **no**
