### PR TITLE
[hotfix] Add missing ASF license headers in backward-compatibility module

### DIFF
--- a/flink-connector-jdbc-backward-compatibility/pom.xml
+++ b/flink-connector-jdbc-backward-compatibility/pom.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/flink-connector-jdbc-backward-compatibility/src/test/java/org/apache/flink/connector/jdbc/backward/compatibility/DynamicTableSourceTest.java
+++ b/flink-connector-jdbc-backward-compatibility/src/test/java/org/apache/flink/connector/jdbc/backward/compatibility/DynamicTableSourceTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.connector.jdbc.backward.compatibility;
 
 import org.apache.flink.configuration.Configuration;


### PR DESCRIPTION
## What is the purpose of the change

Backport of apache/flink-connector-jdbc#205 to the `v3.4` release branch.

The `flink-connector-jdbc-backward-compatibility` module ships two files that are missing the Apache license header every other source file in the repository carries:

- `flink-connector-jdbc-backward-compatibility/pom.xml`
- `flink-connector-jdbc-backward-compatibility/src/test/java/org/apache/flink/connector/jdbc/backward/compatibility/DynamicTableSourceTest.java`

Both files are included in the `flink-connector-jdbc-3.4.0` source distribution (observed while verifying the RC3 source release). The module's three sibling test files already carry the header.

## Why it isn't caught by CI

The module is intentionally excluded from the parent pom's `<modules>` so it can be built standalone against multiple Flink versions. Two consequences follow:

- The repository-wide Apache RAT check is bound to the `verify` phase of the root reactor, which never includes this module.
- The dedicated `backwards_compatibility.yml` workflow runs `mvn ... test` inside the module directory, which stops before the `verify` phase where RAT runs.

So neither path exercises RAT on these two files.

## Brief change log

- Add the standard ASF license header to `pom.xml` and `DynamicTableSourceTest.java`, byte-identical to the header already present on the module's sibling files.

## Verifying this change

License-header-only change; no production or test logic is touched. Verified locally that `mvn apache-rat:check` reports both files as `AL` (approved license) after the change; before the change they were flagged as unapproved.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
