### PR TITLE
[FLINK-40108] Adding snapshot capability with split enumerator

### DIFF
--- a/flink-connector-jdbc-core/pom.xml
+++ b/flink-connector-jdbc-core/pom.xml
@@ -46,6 +46,17 @@ under the License.
         </dependency>
 
         <!-- Table ecosystem -->
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>7.0.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
         <!-- Projects depending on this project won't depend on flink-table-*. -->
         <dependency>

--- a/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/connection/AbstractConnectionProvider.java
+++ b/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/connection/AbstractConnectionProvider.java
@@ -1,0 +1,447 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.core.datastream.connection;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain.TableColumn;
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain.TableId;
+import org.apache.flink.util.Preconditions;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Base {@link ConnectionProvider} that implements the connection lifecycle, pooling, and
+ * prepared-statement plumbing shared by every dialect-specific provider. Subclasses only need to
+ * implement the dialect-specific table discovery and bound-query building methods declared by
+ * {@link ConnectionProvider} (e.g. {@code getTables}, {@code queryMinMax}, {@code
+ * queryNextChunkMax}, {@code createQueryWithBounds}, {@code newInstance}).
+ */
+@Internal
+public abstract class AbstractConnectionProvider implements ConnectionProvider {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractConnectionProvider.class);
+
+    private static final int DEFAULT_POOL_SIZE = 4;
+    private static final int MINIMUM_POOL_SIZE = 1;
+
+    protected final ConnectionOptions jdbcOptions;
+    private int queryTimeoutSeconds;
+    private transient Driver loadedDriver;
+    private transient Connection connection;
+    private final Map<String, PreparedStatement> statementCache;
+    private transient HikariDataSource connectionPool;
+    private final boolean poolOwner;
+
+    static {
+        // Load DriverManager first to avoid deadlock between DriverManager's
+        // static initialization block and specific driver class's static
+        // initialization block when two different driver classes are loading
+        // concurrently using Class.forName while DriverManager is uninitialized
+        // before.
+        //
+        // This could happen in JDK 8 but not above as driver loading has been
+        // moved out of DriverManager's static initialization block since JDK 9.
+        DriverManager.getDrivers();
+    }
+
+    protected AbstractConnectionProvider(ConnectionOptions jdbcOptions) {
+        this.jdbcOptions = jdbcOptions;
+        this.statementCache = new ConcurrentHashMap<>();
+        this.queryTimeoutSeconds = jdbcOptions.getConnectionQueryTimeoutSeconds();
+        this.poolOwner = true;
+        try {
+            // Establish the raw connection directly rather than via getOrEstablishConnection():
+            // that method invokes the overridable onConnectionEstablished() hook, which a
+            // subclass may depend on its own fields for — fields that aren't initialized yet
+            // while this superclass constructor is still running.
+            establishConnection();
+        } catch (Exception e) {
+            throw new ConnectionException(
+                    "Failed to establish initial connection during connection provider construction.",
+                    e);
+        }
+    }
+
+    /**
+     * Creates a pooled instance that borrows its connection from the given pool. This instance does
+     * NOT own the pool and will not shut it down on close.
+     */
+    protected AbstractConnectionProvider(ConnectionOptions jdbcOptions, HikariDataSource pool) {
+        this.jdbcOptions = jdbcOptions;
+        this.statementCache = new ConcurrentHashMap<>();
+        this.queryTimeoutSeconds = jdbcOptions.getConnectionQueryTimeoutSeconds();
+        this.connectionPool = pool;
+        this.poolOwner = false;
+        try {
+            this.connection = pool.getConnection();
+        } catch (SQLException e) {
+            throw new ConnectionException("Failed to borrow connection from pool.", e);
+        }
+    }
+
+    protected synchronized HikariDataSource getOrCreatePool() {
+        if (connectionPool == null) {
+            connectionPool = createConnectionPool();
+        }
+        return connectionPool;
+    }
+
+    private HikariDataSource createConnectionPool() {
+        HikariConfig config = new HikariConfig();
+        // Provide a DataSource directly so HikariCP doesn't try to load the driver
+        // via its own classloader. In Flink, the JDBC driver lives in the user
+        // classloader and is not visible to HikariCP's threads. Using this driver
+        // delegate guarantees connections are created with the same code path as
+        // getOrEstablishConnection().
+        config.setDataSource(new ConnectionDataSource(jdbcOptions, this::getLoadedDriver));
+        config.setMinimumIdle(MINIMUM_POOL_SIZE);
+        config.setMaximumPoolSize(maxPoolSize());
+        config.setConnectionTimeout(
+                Duration.ofSeconds(jdbcOptions.getConnectionCheckTimeoutSeconds()).toMillis());
+        config.setPoolName(poolName());
+        LOG.info("Creating HikariCP connection pool with maxPoolSize={}", maxPoolSize());
+        return new HikariDataSource(config);
+    }
+
+    /** Maximum number of pooled connections. Override to change the pool size. */
+    protected int maxPoolSize() {
+        return DEFAULT_POOL_SIZE;
+    }
+
+    /** Name used for the HikariCP pool, shown in logs/metrics. */
+    protected String poolName() {
+        return getClass().getSimpleName() + "-pool";
+    }
+
+    /**
+     * Hook invoked every time a connection is (re-)established, before it's handed back to the
+     * caller. No-op by default; dialect-specific subclasses can override to re-apply
+     * connection-scoped state (e.g. re-syncing a shared snapshot transaction id).
+     */
+    protected void onConnectionEstablished() throws SQLException {}
+
+    @Override
+    public Connection getConnection() {
+        return connection;
+    }
+
+    @Nonnull
+    @Override
+    public Properties getProperties() {
+        return jdbcOptions.getProperties();
+    }
+
+    @Override
+    public boolean isConnectionValid() throws SQLException {
+        return connection != null
+                && !connection.isClosed()
+                && connection.isValid(jdbcOptions.getConnectionCheckTimeoutSeconds());
+    }
+
+    private Driver loadDriver(String driverName) throws SQLException, ClassNotFoundException {
+        Preconditions.checkNotNull(driverName);
+        Enumeration<Driver> drivers = DriverManager.getDrivers();
+        while (drivers.hasMoreElements()) {
+            Driver driver = drivers.nextElement();
+            if (driver.getClass().getName().equals(driverName)) {
+                return driver;
+            }
+        }
+        // We could reach here for reasons:
+        // * Class loader hell of DriverManager(see JDK-8146872).
+        // * driver is not installed as a service provider.
+        Class<?> clazz =
+                Class.forName(driverName, true, Thread.currentThread().getContextClassLoader());
+        try {
+            return (Driver) clazz.getDeclaredConstructor().newInstance();
+        } catch (Exception ex) {
+            throw new SQLException("Fail to create driver of class " + driverName, ex);
+        }
+    }
+
+    private Driver getLoadedDriver() throws SQLException, ClassNotFoundException {
+        if (loadedDriver == null) {
+            loadedDriver = loadDriver(jdbcOptions.getDriverName());
+        }
+        return loadedDriver;
+    }
+
+    @Override
+    public Connection getOrEstablishConnection() throws SQLException, ClassNotFoundException {
+        if (isConnectionValid()) {
+            onConnectionEstablished();
+            return connection;
+        }
+        establishConnection();
+        onConnectionEstablished();
+        return connection;
+    }
+
+    /**
+     * Establishes a fresh {@link #connection}. Does not invoke {@link #onConnectionEstablished()}.
+     */
+    private Connection establishConnection() throws SQLException, ClassNotFoundException {
+        String connectionUrl = jdbcOptions.getDbURL();
+        if (jdbcOptions.getDriverName() == null) {
+            connection = DriverManager.getConnection(connectionUrl, getProperties());
+        } else {
+            Driver driver = getLoadedDriver();
+            connection = driver.connect(connectionUrl, getProperties());
+            if (connection == null) {
+                // Throw same exception as DriverManager.getConnection when no driver found to match
+                // caller expectation.
+                throw new SQLException("No suitable driver found for " + connectionUrl, "08001");
+            }
+        }
+        return connection;
+    }
+
+    @Override
+    public Connection reestablishConnection() throws SQLException, ClassNotFoundException {
+        closeConnection();
+        return getOrEstablishConnection();
+    }
+
+    public void withQueryTimeout(Duration queryTimeout) {
+        Objects.requireNonNull(queryTimeout, "queryTimeout must be provided");
+        if (queryTimeout.isZero() || queryTimeout.isNegative()) {
+            throw new IllegalArgumentException("queryTimeout must be positive");
+        }
+        this.queryTimeoutSeconds = (int) queryTimeout.getSeconds();
+    }
+
+    private Set<String> getPrimaryKeys(TableId tableId) {
+        Set<String> primaryKeys = new HashSet<>();
+        try (ResultSet rs =
+                getOrEstablishConnection()
+                        .getMetaData()
+                        .getPrimaryKeys(
+                                tableId.catalogName(), tableId.schemaName(), tableId.tableName())) {
+            while (rs.next()) {
+                primaryKeys.add(rs.getString(4));
+            }
+        } catch (SQLException | ClassNotFoundException e) {
+            throw new ConnectionException("Failed to get primary keys for table " + tableId, e);
+        }
+        return primaryKeys;
+    }
+
+    @Override
+    public Set<TableColumn> getTableColumns(TableId tableId) {
+        Set<String> tablePrimaryKeys = getPrimaryKeys(tableId);
+        Set<TableColumn> tableColumns = new LinkedHashSet<>();
+        try (ResultSet rs =
+                getOrEstablishConnection()
+                        .getMetaData()
+                        .getColumns(
+                                tableId.catalogName(),
+                                tableId.schemaName(),
+                                tableId.tableName(),
+                                (String) null)) {
+            while (rs.next()) {
+                String columnName = rs.getString(4);
+                TableColumn column =
+                        TableColumn.builder()
+                                .withColumnName(columnName)
+                                .withColumnType(rs.getString(6))
+                                .withColumnPosition(rs.getInt(17))
+                                .withColumnNullable(isNullable(rs.getInt(11)))
+                                .withColumnPk(tablePrimaryKeys.contains(columnName))
+                                .build();
+                tableColumns.add(column);
+            }
+        } catch (SQLException | ClassNotFoundException e) {
+            throw new ConnectionException(
+                    String.format("Failed to get columns for table %s", tableId), e);
+        }
+        return tableColumns;
+    }
+
+    protected static boolean isNullable(int jdbcNullable) {
+        return jdbcNullable == ResultSetMetaData.columnNullable
+                || jdbcNullable == ResultSetMetaData.columnNullableUnknown;
+    }
+
+    protected <T> T queryAndMap(String query, ResultSetMapper<T> mapper) {
+        Objects.requireNonNull(mapper, "Mapper must be provided");
+        try (Statement statement = createStatement()) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("running '{}' with {}s timeout", query, this.queryTimeoutSeconds);
+            }
+
+            try (ResultSet resultSet = statement.executeQuery(query)) {
+                return mapper.apply(resultSet);
+            }
+        } catch (Exception e) {
+            throw new ConnectionException(String.format("Failed executing query %s", query), e);
+        }
+    }
+
+    private Statement createStatement() {
+        try {
+            final Statement statement = getOrEstablishConnection().createStatement();
+            initializeStatement(statement);
+            return statement;
+        } catch (SQLException | ClassNotFoundException e) {
+            throw new ConnectionException("Failed to create statement from factory", e);
+        }
+    }
+
+    protected <T> T prepareQueryAndMap(
+            String preparedQuery, StatementPreparer preparer, ResultSetMapper<T> mapper) {
+        Objects.requireNonNull(mapper, "Mapper must be provided");
+        try {
+            PreparedStatement statement = prepareQuery(preparedQuery, preparer);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                return mapper.apply(resultSet);
+            }
+        } catch (Exception e) {
+            throw new ConnectionException(
+                    String.format("Failed executing query %s", preparedQuery), e);
+        }
+    }
+
+    private PreparedStatement prepareQuery(String preparedQuery, StatementPreparer preparer) {
+        try {
+            PreparedStatement statement = this.createPreparedStatement(preparedQuery);
+            preparer.accept(statement);
+            return statement;
+        } catch (SQLException e) {
+            throw new ConnectionException("Failed to prepare query", e);
+        }
+    }
+
+    private PreparedStatement createPreparedStatement(String preparedQueryString) {
+        return this.statementCache.computeIfAbsent(
+                preparedQueryString,
+                (query) -> {
+                    try {
+                        LOG.trace(
+                                "Inserting prepared statement '{}' that does not exist in the cache",
+                                query);
+                        PreparedStatement preparedStatement =
+                                getOrEstablishConnection().prepareStatement(query);
+                        initializeStatement(preparedStatement);
+                        if (LOG.isTraceEnabled()) {
+                            LOG.trace(
+                                    "PreparedStatement '{}' with {}s timeout",
+                                    preparedQueryString,
+                                    this.queryTimeoutSeconds);
+                        }
+                        return preparedStatement;
+                    } catch (SQLException | ClassNotFoundException e) {
+                        throw new ConnectionException(e);
+                    }
+                });
+    }
+
+    private void initializeStatement(Statement statement) {
+        try {
+            statement.setQueryTimeout(queryTimeoutSeconds);
+        } catch (SQLException e) {
+            throw new ConnectionException("Failed to add timeout to statement", e);
+        }
+    }
+
+    private void closePreparedStatement(PreparedStatement statement) {
+        LOG.trace("Closing prepared statement '{}' removed from cache", statement);
+        try {
+            statement.close();
+        } catch (Exception e) {
+            LOG.info("Exception while closing a prepared statement removed from cache", e);
+        }
+    }
+
+    @Override
+    public void closeConnection() {
+        if (connection == null) {
+            return;
+        }
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Future<Object> futureClose =
+                executor.submit(
+                        () -> {
+                            this.connection.close();
+                            LOG.info("Connection gracefully closed");
+                            return null;
+                        });
+
+        try {
+            futureClose.get(10L, TimeUnit.SECONDS);
+        } catch (ExecutionException e) {
+            throw new ConnectionException(e.getCause());
+        } catch (InterruptedException | TimeoutException e) {
+            try {
+                LOG.warn(
+                        "Failed to close database connection by calling close(), attempting abort()");
+                this.connection.abort(Runnable::run);
+            } catch (SQLException ex) {
+                throw new ConnectionException(ex);
+            }
+        } finally {
+            executor.shutdownNow();
+            try {
+                if (this.connection != null
+                        && !this.connection.isClosed()
+                        && !connection.getAutoCommit()) {
+                    this.connection.rollback();
+                }
+            } catch (SQLException e) {
+                LOG.warn("Failed to rollback connection during close", e);
+            } finally {
+                this.statementCache.values().forEach(this::closePreparedStatement);
+                this.statementCache.clear();
+                this.connection = null;
+            }
+        }
+        if (poolOwner && connectionPool != null) {
+            LOG.info("Shutting down connection pool");
+            connectionPool.close();
+            connectionPool = null;
+        }
+    }
+}

--- a/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/connection/AbstractConnectionProvider.java
+++ b/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/connection/AbstractConnectionProvider.java
@@ -1,0 +1,451 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.core.datastream.connection;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain.TableColumn;
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain.TableId;
+import org.apache.flink.util.Preconditions;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Base {@link ConnectionProvider} that implements the connection lifecycle, pooling, and
+ * prepared-statement plumbing shared by every dialect-specific provider. Subclasses only need to
+ * implement the dialect-specific table discovery and bound-query building methods declared by
+ * {@link ConnectionProvider} (e.g. {@code getTables}, {@code queryMinMax}, {@code
+ * queryNextChunkMax}, {@code createQueryWithBounds}, {@code newInstance}).
+ */
+@Internal
+public abstract class AbstractConnectionProvider implements ConnectionProvider {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractConnectionProvider.class);
+
+    private static final int DEFAULT_POOL_SIZE = 4;
+    private static final int MINIMUM_POOL_SIZE = 1;
+
+    protected final ConnectionOptions jdbcOptions;
+    private int queryTimeoutSeconds;
+    private transient Driver loadedDriver;
+    private transient Connection connection;
+    private final Map<String, PreparedStatement> statementCache;
+    private transient HikariDataSource connectionPool;
+    private final boolean poolOwner;
+
+    static {
+        // Load DriverManager first to avoid deadlock between DriverManager's
+        // static initialization block and specific driver class's static
+        // initialization block when two different driver classes are loading
+        // concurrently using Class.forName while DriverManager is uninitialized
+        // before.
+        //
+        // This could happen in JDK 8 but not above as driver loading has been
+        // moved out of DriverManager's static initialization block since JDK 9.
+        DriverManager.getDrivers();
+    }
+
+    protected AbstractConnectionProvider(ConnectionOptions jdbcOptions) {
+        this.jdbcOptions = jdbcOptions;
+        this.statementCache = new ConcurrentHashMap<>();
+        this.queryTimeoutSeconds = jdbcOptions.getConnectionQueryTimeoutSeconds();
+        this.poolOwner = true;
+        try {
+            // Establish the raw connection directly rather than via getOrEstablishConnection():
+            // that method invokes the overridable onConnectionEstablished() hook, which a
+            // subclass may depend on its own fields for — fields that aren't initialized yet
+            // while this superclass constructor is still running.
+            establishConnection();
+        } catch (Exception e) {
+            throw new ConnectionException(
+                    "Failed to establish initial connection during connection provider construction.",
+                    e);
+        }
+    }
+
+    /**
+     * Creates a pooled instance that borrows its connection from the given pool. This instance does
+     * NOT own the pool and will not shut it down on close.
+     */
+    protected AbstractConnectionProvider(ConnectionOptions jdbcOptions, HikariDataSource pool) {
+        this.jdbcOptions = jdbcOptions;
+        this.statementCache = new ConcurrentHashMap<>();
+        this.queryTimeoutSeconds = jdbcOptions.getConnectionQueryTimeoutSeconds();
+        this.connectionPool = pool;
+        this.poolOwner = false;
+        try {
+            this.connection = pool.getConnection();
+        } catch (SQLException e) {
+            throw new ConnectionException("Failed to borrow connection from pool.", e);
+        }
+    }
+
+    protected synchronized HikariDataSource getOrCreatePool() {
+        if (connectionPool == null) {
+            connectionPool = createConnectionPool();
+        }
+        return connectionPool;
+    }
+
+    private HikariDataSource createConnectionPool() {
+        HikariConfig config = new HikariConfig();
+        // Provide a DataSource directly so HikariCP doesn't try to load the driver
+        // via its own classloader. In Flink, the JDBC driver lives in the user
+        // classloader and is not visible to HikariCP's threads. Using this driver
+        // delegate guarantees connections are created with the same code path as
+        // getOrEstablishConnection().
+        config.setDataSource(new ConnectionDataSource(jdbcOptions, this::getLoadedDriver));
+        config.setMinimumIdle(MINIMUM_POOL_SIZE);
+        config.setMaximumPoolSize(maxPoolSize());
+        config.setConnectionTimeout(
+                Duration.ofSeconds(jdbcOptions.getConnectionCheckTimeoutSeconds()).toMillis());
+        config.setPoolName(poolName());
+        LOG.info("Creating HikariCP connection pool with maxPoolSize={}", maxPoolSize());
+        return new HikariDataSource(config);
+    }
+
+    /** Maximum number of pooled connections. Override to change the pool size. */
+    protected int maxPoolSize() {
+        return DEFAULT_POOL_SIZE;
+    }
+
+    /** Name used for the HikariCP pool, shown in logs/metrics. */
+    protected String poolName() {
+        return getClass().getSimpleName() + "-pool";
+    }
+
+    /**
+     * Hook invoked every time a connection is (re-)established, before it's handed back to the
+     * caller. No-op by default; dialect-specific subclasses can override to re-apply
+     * connection-scoped state (e.g. re-syncing a shared snapshot transaction id).
+     */
+    protected void onConnectionEstablished() throws SQLException {}
+
+    @Override
+    public Connection getConnection() {
+        return connection;
+    }
+
+    @Nonnull
+    @Override
+    public Properties getProperties() {
+        return jdbcOptions.getProperties();
+    }
+
+    @Override
+    public boolean isConnectionValid() throws SQLException {
+        return connection != null
+                && !connection.isClosed()
+                && connection.isValid(jdbcOptions.getConnectionCheckTimeoutSeconds());
+    }
+
+    private Driver loadDriver(String driverName) throws SQLException, ClassNotFoundException {
+        Preconditions.checkNotNull(driverName);
+        Enumeration<Driver> drivers = DriverManager.getDrivers();
+        while (drivers.hasMoreElements()) {
+            Driver driver = drivers.nextElement();
+            if (driver.getClass().getName().equals(driverName)) {
+                return driver;
+            }
+        }
+        // We could reach here for reasons:
+        // * Class loader hell of DriverManager(see JDK-8146872).
+        // * driver is not installed as a service provider.
+        Class<?> clazz =
+                Class.forName(driverName, true, Thread.currentThread().getContextClassLoader());
+        try {
+            return (Driver) clazz.getDeclaredConstructor().newInstance();
+        } catch (Exception ex) {
+            throw new SQLException("Fail to create driver of class " + driverName, ex);
+        }
+    }
+
+    private Driver getLoadedDriver() throws SQLException, ClassNotFoundException {
+        if (loadedDriver == null) {
+            loadedDriver = loadDriver(jdbcOptions.getDriverName());
+        }
+        return loadedDriver;
+    }
+
+    @Override
+    public Connection getOrEstablishConnection() throws SQLException, ClassNotFoundException {
+        if (isConnectionValid()) {
+            onConnectionEstablished();
+            return connection;
+        }
+        establishConnection();
+        onConnectionEstablished();
+        return connection;
+    }
+
+    /**
+     * Establishes a fresh {@link #connection}. Does not invoke {@link #onConnectionEstablished()}.
+     */
+    private void establishConnection() throws SQLException, ClassNotFoundException {
+        if (!poolOwner) {
+            // connectionPool is guaranteed non-null here: the pool-borrowing constructor requires it.
+            connection = connectionPool.getConnection();
+            return;
+        }
+        String connectionUrl = jdbcOptions.getDbURL();
+        if (jdbcOptions.getDriverName() == null) {
+            connection = DriverManager.getConnection(connectionUrl, getProperties());
+        } else {
+            Driver driver = getLoadedDriver();
+            connection = driver.connect(connectionUrl, getProperties());
+            if (connection == null) {
+                // Throw same exception as DriverManager.getConnection when no driver found to match
+                // caller expectation.
+                throw new SQLException("No suitable driver found for " + connectionUrl, "08001");
+            }
+        }
+    }
+
+    @Override
+    public Connection reestablishConnection() throws SQLException, ClassNotFoundException {
+        closeConnection();
+        return getOrEstablishConnection();
+    }
+
+    public void withQueryTimeout(Duration queryTimeout) {
+        Objects.requireNonNull(queryTimeout, "queryTimeout must be provided");
+        if (queryTimeout.isZero() || queryTimeout.isNegative()) {
+            throw new IllegalArgumentException("queryTimeout must be positive");
+        }
+        this.queryTimeoutSeconds = (int) queryTimeout.getSeconds();
+    }
+
+    private Set<String> getPrimaryKeys(TableId tableId) {
+        Set<String> primaryKeys = new HashSet<>();
+        try (ResultSet rs =
+                getOrEstablishConnection()
+                        .getMetaData()
+                        .getPrimaryKeys(
+                                tableId.catalogName(), tableId.schemaName(), tableId.tableName())) {
+            while (rs.next()) {
+                primaryKeys.add(rs.getString(4));
+            }
+        } catch (SQLException | ClassNotFoundException e) {
+            throw new ConnectionException("Failed to get primary keys for table " + tableId, e);
+        }
+        return primaryKeys;
+    }
+
+    @Override
+    public Set<TableColumn> getTableColumns(TableId tableId) {
+        Set<String> tablePrimaryKeys = getPrimaryKeys(tableId);
+        Set<TableColumn> tableColumns = new LinkedHashSet<>();
+        try (ResultSet rs =
+                getOrEstablishConnection()
+                        .getMetaData()
+                        .getColumns(
+                                tableId.catalogName(),
+                                tableId.schemaName(),
+                                tableId.tableName(),
+                                (String) null)) {
+            while (rs.next()) {
+                String columnName = rs.getString(4);
+                TableColumn column =
+                        TableColumn.builder()
+                                .withColumnName(columnName)
+                                .withColumnType(rs.getString(6))
+                                .withColumnPosition(rs.getInt(17))
+                                .withColumnNullable(isNullable(rs.getInt(11)))
+                                .withColumnPk(tablePrimaryKeys.contains(columnName))
+                                .build();
+                tableColumns.add(column);
+            }
+        } catch (SQLException | ClassNotFoundException e) {
+            throw new ConnectionException(
+                    String.format("Failed to get columns for table %s", tableId), e);
+        }
+        return tableColumns;
+    }
+
+    protected static boolean isNullable(int jdbcNullable) {
+        return jdbcNullable == ResultSetMetaData.columnNullable
+                || jdbcNullable == ResultSetMetaData.columnNullableUnknown;
+    }
+
+    protected <T> T queryAndMap(String query, ResultSetMapper<T> mapper) {
+        Objects.requireNonNull(mapper, "Mapper must be provided");
+        try (Statement statement = createStatement()) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("running '{}' with {}s timeout", query, this.queryTimeoutSeconds);
+            }
+
+            try (ResultSet resultSet = statement.executeQuery(query)) {
+                return mapper.apply(resultSet);
+            }
+        } catch (Exception e) {
+            throw new ConnectionException(String.format("Failed executing query %s", query), e);
+        }
+    }
+
+    private Statement createStatement() {
+        try {
+            final Statement statement = getOrEstablishConnection().createStatement();
+            initializeStatement(statement);
+            return statement;
+        } catch (SQLException | ClassNotFoundException e) {
+            throw new ConnectionException("Failed to create statement from factory", e);
+        }
+    }
+
+    protected <T> T prepareQueryAndMap(
+            String preparedQuery, StatementPreparer preparer, ResultSetMapper<T> mapper) {
+        Objects.requireNonNull(mapper, "Mapper must be provided");
+        try {
+            PreparedStatement statement = prepareQuery(preparedQuery, preparer);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                return mapper.apply(resultSet);
+            }
+        } catch (Exception e) {
+            throw new ConnectionException(
+                    String.format("Failed executing query %s", preparedQuery), e);
+        }
+    }
+
+    private PreparedStatement prepareQuery(String preparedQuery, StatementPreparer preparer) {
+        try {
+            PreparedStatement statement = this.createPreparedStatement(preparedQuery);
+            preparer.accept(statement);
+            return statement;
+        } catch (SQLException e) {
+            throw new ConnectionException("Failed to prepare query", e);
+        }
+    }
+
+    private PreparedStatement createPreparedStatement(String preparedQueryString) {
+        return this.statementCache.computeIfAbsent(
+                preparedQueryString,
+                (query) -> {
+                    try {
+                        LOG.trace(
+                                "Inserting prepared statement '{}' that does not exist in the cache",
+                                query);
+                        PreparedStatement preparedStatement =
+                                getOrEstablishConnection().prepareStatement(query);
+                        initializeStatement(preparedStatement);
+                        if (LOG.isTraceEnabled()) {
+                            LOG.trace(
+                                    "PreparedStatement '{}' with {}s timeout",
+                                    preparedQueryString,
+                                    this.queryTimeoutSeconds);
+                        }
+                        return preparedStatement;
+                    } catch (SQLException | ClassNotFoundException e) {
+                        throw new ConnectionException(e);
+                    }
+                });
+    }
+
+    private void initializeStatement(Statement statement) {
+        try {
+            statement.setQueryTimeout(queryTimeoutSeconds);
+        } catch (SQLException e) {
+            throw new ConnectionException("Failed to add timeout to statement", e);
+        }
+    }
+
+    private void closePreparedStatement(PreparedStatement statement) {
+        LOG.trace("Closing prepared statement '{}' removed from cache", statement);
+        try {
+            statement.close();
+        } catch (Exception e) {
+            LOG.info("Exception while closing a prepared statement removed from cache", e);
+        }
+    }
+
+    @Override
+    public void closeConnection() {
+        if (connection == null) {
+            return;
+        }
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Future<Object> futureClose =
+                executor.submit(
+                        () -> {
+                            this.connection.close();
+                            LOG.info("Connection gracefully closed");
+                            return null;
+                        });
+
+        try {
+            futureClose.get(10L, TimeUnit.SECONDS);
+        } catch (ExecutionException e) {
+            throw new ConnectionException(e.getCause());
+        } catch (InterruptedException | TimeoutException e) {
+            try {
+                LOG.warn(
+                        "Failed to close database connection by calling close(), attempting abort()");
+                this.connection.abort(Runnable::run);
+            } catch (SQLException ex) {
+                throw new ConnectionException(ex);
+            }
+        } finally {
+            executor.shutdownNow();
+            try {
+                if (this.connection != null
+                        && !this.connection.isClosed()
+                        && !connection.getAutoCommit()) {
+                    this.connection.rollback();
+                }
+            } catch (SQLException e) {
+                LOG.warn("Failed to rollback connection during close", e);
+            } finally {
+                this.statementCache.values().forEach(this::closePreparedStatement);
+                this.statementCache.clear();
+                this.connection = null;
+            }
+        }
+        if (poolOwner && connectionPool != null) {
+            LOG.info("Shutting down connection pool");
+            connectionPool.close();
+            connectionPool = null;
+        }
+    }
+}

--- a/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/connection/ConnectionDataSource.java
+++ b/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/connection/ConnectionDataSource.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.core.datastream.connection;
+
+import org.apache.flink.annotation.Internal;
+
+import javax.sql.DataSource;
+
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Properties;
+
+/**
+ * Minimal {@link DataSource} that delegates connection creation to a {@link DriverResolver} instead
+ * of resolving/loading the driver itself. Used to back a HikariCP pool so every pooled connection
+ * is created via the same classloader-aware driver resolution as the rest of a {@link
+ * ConnectionProvider} — in Flink, the JDBC driver lives in the user classloader, which HikariCP's
+ * own driver-loading path may not see.
+ */
+@Internal
+public class ConnectionDataSource implements DataSource {
+
+    /** Resolves the JDBC {@link Driver} to use for new connections. */
+    @Internal
+    @FunctionalInterface
+    public interface DriverResolver {
+        Driver resolve() throws SQLException, ClassNotFoundException;
+    }
+
+    private final ConnectionOptions jdbcOptions;
+    private final DriverResolver driverResolver;
+
+    public ConnectionDataSource(ConnectionOptions jdbcOptions, DriverResolver driverResolver) {
+        this.jdbcOptions = jdbcOptions;
+        this.driverResolver = driverResolver;
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        try {
+            String url = jdbcOptions.getDbURL();
+            Properties props = jdbcOptions.getProperties();
+            if (jdbcOptions.getDriverName() == null) {
+                return DriverManager.getConnection(url, props);
+            }
+            Driver driver = driverResolver.resolve();
+            Connection conn = driver.connect(url, props);
+            if (conn == null) {
+                throw new SQLException("No suitable driver found for " + url, "08001");
+            }
+            return conn;
+        } catch (ClassNotFoundException e) {
+            throw new SQLException("Failed to load driver", e);
+        }
+    }
+
+    @Override
+    public Connection getConnection(String username, String password) throws SQLException {
+        return getConnection();
+    }
+
+    @Override
+    public PrintWriter getLogWriter() {
+        return null;
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter out) {}
+
+    @Override
+    public void setLoginTimeout(int seconds) {}
+
+    @Override
+    public int getLoginTimeout() {
+        return 0;
+    }
+
+    @Override
+    public java.util.logging.Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        throw new SQLException("Not a wrapper for " + iface);
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) {
+        return false;
+    }
+}

--- a/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/connection/ConnectionException.java
+++ b/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/connection/ConnectionException.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.core.datastream.connection;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/** Exception thrown when there is an issue connecting to the database. */
+@PublicEvolving
+public class ConnectionException extends RuntimeException {
+
+    public ConnectionException(String message) {
+        super(message);
+    }
+
+    public ConnectionException(Throwable cause) {
+        super(cause);
+    }
+
+    public ConnectionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/connection/ConnectionOptions.java
+++ b/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/connection/ConnectionOptions.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.core.datastream.connection;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.connector.jdbc.JdbcConnectionOptions;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.time.Duration;
+import java.util.Properties;
+
+/** Connection options for a {@link ConnectionProvider}, extending the base JDBC options. */
+@PublicEvolving
+public class ConnectionOptions extends JdbcConnectionOptions {
+
+    private final int connectionQueryTimeoutSeconds;
+
+    protected ConnectionOptions(
+            @Nonnull String url,
+            @Nullable String driverName,
+            @Nonnull Duration connectionCheckTimeout,
+            @Nonnull Duration connectionQueryTimeout,
+            @Nonnull Properties properties) {
+        super(url, driverName, Math.toIntExact(connectionCheckTimeout.getSeconds()), properties);
+        this.connectionQueryTimeoutSeconds = Math.toIntExact(connectionQueryTimeout.getSeconds());
+    }
+
+    public int getConnectionQueryTimeoutSeconds() {
+        return connectionQueryTimeoutSeconds;
+    }
+
+    public static ConnectionOptionsBuilder builder() {
+        return new ConnectionOptionsBuilder();
+    }
+}

--- a/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/connection/ConnectionOptionsBuilder.java
+++ b/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/connection/ConnectionOptionsBuilder.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.core.datastream.connection;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Properties;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Builder for creating instances of {@link ConnectionOptions}. */
+@PublicEvolving
+public class ConnectionOptionsBuilder {
+
+    private String url;
+    private String driverName;
+    private Duration connectionCheckTimeout = Duration.ofSeconds(60);
+    private Duration connectionQueryTimeout = Duration.ofSeconds(60);
+    private final Properties properties = new Properties();
+
+    public ConnectionOptionsBuilder withUrl(String url) {
+        this.url = url;
+        return this;
+    }
+
+    public ConnectionOptionsBuilder withDriverName(String driverName) {
+        this.driverName = driverName;
+        return this;
+    }
+
+    public ConnectionOptionsBuilder withProperty(String propKey, String propVal) {
+        checkNotNull(propKey, "Connection property key mustn't be null");
+        checkNotNull(propVal, "Connection property value mustn't be null");
+        this.properties.put(propKey, propVal);
+        return this;
+    }
+
+    public ConnectionOptionsBuilder withUsername(String username) {
+        if (Objects.nonNull(username)) {
+            this.properties.put("user", username);
+        }
+
+        return this;
+    }
+
+    public ConnectionOptionsBuilder withPassword(String password) {
+        if (Objects.nonNull(password)) {
+            this.properties.put("password", password);
+        }
+
+        return this;
+    }
+
+    public ConnectionOptionsBuilder withConnectionCheckTimeout(Duration connectionCheckTimeout) {
+        checkNotNull(connectionCheckTimeout, "Connection check timeout mustn't be null");
+        this.connectionCheckTimeout = connectionCheckTimeout;
+        return this;
+    }
+
+    public ConnectionOptionsBuilder withConnectionQueryTimeout(Duration connectionQueryTimeout) {
+        checkNotNull(connectionQueryTimeout, "Connection query timeout mustn't be null");
+        this.connectionQueryTimeout = connectionQueryTimeout;
+        return this;
+    }
+
+    public ConnectionOptions build() {
+        return new ConnectionOptions(
+                this.url,
+                this.driverName,
+                this.connectionCheckTimeout,
+                this.connectionQueryTimeout,
+                this.properties);
+    }
+}

--- a/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/connection/ConnectionProvider.java
+++ b/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/connection/ConnectionProvider.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.core.datastream.connection;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain.Table;
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain.TableBounds;
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain.TableColumn;
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain.TableId;
+import org.apache.flink.connector.jdbc.datasource.connections.JdbcConnectionProvider;
+
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * A {@link JdbcConnectionProvider} extended with the table/column metadata discovery and
+ * bound-query building needed by the snapshot splitters.
+ */
+@PublicEvolving
+public interface ConnectionProvider extends JdbcConnectionProvider {
+
+    Set<Table> getTables(String catalog, String schema);
+
+    Set<TableColumn> getTableColumns(TableId tableId);
+
+    String createQueryWithBounds(
+            TableId tableId, Set<String> tableColumns, TableColumn pkColumn, TableBounds bounds);
+
+    TableBounds queryMinMax(TableId tableId, TableColumn column);
+
+    Optional<Object> queryNextChunkMax(
+            TableId tableId, TableColumn column, Object lowerBound, long chunkSize);
+
+    /**
+     * Creates a new independent instance of this provider backed by its own connection. When a
+     * connection pool is configured, the new instance borrows from the shared pool. The caller is
+     * responsible for closing the returned instance to release its connection.
+     */
+    ConnectionProvider newInstance();
+}

--- a/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/connection/ResultSetMapper.java
+++ b/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/connection/ResultSetMapper.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.core.datastream.connection;
+
+import org.apache.flink.annotation.Internal;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * A functional interface for mapping a {@link ResultSet} to an object of type T.
+ *
+ * @param <T> The type of the object to map to.
+ */
+@Internal
+public interface ResultSetMapper<T> {
+    T apply(ResultSet rs) throws SQLException;
+}

--- a/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/connection/StatementPreparer.java
+++ b/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/connection/StatementPreparer.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.core.datastream.connection;
+
+import org.apache.flink.annotation.Internal;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+/** A functional interface for preparing a {@link PreparedStatement} before execution. */
+@Internal
+public interface StatementPreparer {
+    void accept(PreparedStatement ps) throws SQLException;
+}

--- a/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/source/enumerator/splitter/snapshot/AsyncSnapshotSplitterEnumerator.java
+++ b/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/source/enumerator/splitter/snapshot/AsyncSnapshotSplitterEnumerator.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot;
+
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.connector.jdbc.core.datastream.connection.ConnectionProvider;
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.SplitterEnumerator;
+import org.apache.flink.connector.jdbc.core.datastream.source.split.JdbcSourceSplit;
+import org.apache.flink.connector.jdbc.datasource.connections.JdbcConnectionProvider;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Shared async background-computation machinery for the snapshot splitters ({@link
+ * TableSplitterEnumerator}, {@link DatabaseSplitterEnumerator}): a single background daemon thread
+ * computes {@code T} items and offers them into a queue, while {@link #enumerateSplits()} drains
+ * and converts whatever's ready — non-blocking apart from a short wait for the very first item.
+ *
+ * @param <T> the type of item the background thread produces, converted to a {@link
+ *     JdbcSourceSplit} at drain time via {@link #toSplit}
+ */
+abstract class AsyncSnapshotSplitterEnumerator<T> implements SplitterEnumerator {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+    private final String name;
+    private final Queue<T> outputQueue = new ConcurrentLinkedQueue<>();
+
+    protected transient ConnectionProvider connection;
+
+    private transient ExecutorService executor;
+    private transient AtomicBoolean workDone;
+    private transient CountDownLatch firstReady;
+    private transient volatile Throwable backgroundFailure;
+
+    protected AsyncSnapshotSplitterEnumerator(String name) {
+        this.name = name;
+    }
+
+    /** Validates and stores the connection provider for use by subclasses. */
+    protected final void initConnection(JdbcConnectionProvider connectionProvider) {
+        if (!(connectionProvider instanceof ConnectionProvider)) {
+            throw new IllegalArgumentException(
+                    "Connection provider must be an instance of "
+                            + ConnectionProvider.class.getSimpleName());
+        }
+        this.connection = (ConnectionProvider) connectionProvider;
+    }
+
+    @Override
+    public final Boundedness getBoundedness() {
+        return Boundedness.CONTINUOUS_UNBOUNDED;
+    }
+
+    /** Starts the background thread that runs {@link #runBackgroundWork()}. */
+    protected final void startBackgroundWork() {
+        this.workDone = new AtomicBoolean(false);
+        this.firstReady = new CountDownLatch(1);
+        this.executor =
+                Executors.newSingleThreadExecutor(
+                        r -> {
+                            Thread t = new Thread(r, "snapshot-compute-" + name);
+                            t.setDaemon(true);
+                            return t;
+                        });
+        executor.submit(
+                () -> {
+                    try {
+                        runBackgroundWork();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } catch (Throwable e) {
+                        log.error("Background computation failed for {}", name, e);
+                        backgroundFailure = e;
+                    } finally {
+                        workDone.set(true);
+                        firstReady.countDown();
+                    }
+                });
+    }
+
+    /** Subclass-specific unit of work; push results via {@link #offer}/{@link #offerAll}. */
+    protected abstract void runBackgroundWork() throws Exception;
+
+    /** Converts a queued item into an emittable split. */
+    protected abstract JdbcSourceSplit toSplit(T item);
+
+    /** Subclass-specific resource cleanup, called after the background thread has stopped. */
+    protected abstract void closeResources();
+
+    /** Offers a single computed item and wakes up anyone waiting on the first-ready signal. */
+    protected final void offer(T item) {
+        outputQueue.add(item);
+        firstReady.countDown();
+    }
+
+    /** Offers a batch of computed items and wakes up anyone waiting on the first-ready signal. */
+    protected final void offerAll(Collection<T> items) {
+        if (!items.isEmpty()) {
+            outputQueue.addAll(items);
+            firstReady.countDown();
+        }
+    }
+
+    @Override
+    public final boolean isAllSplitsFinished() {
+        return workDone != null && workDone.get() && outputQueue.isEmpty();
+    }
+
+    @Override
+    public final List<JdbcSourceSplit> enumerateSplits() {
+        // Wait briefly for the background thread to produce at least one item.
+        if (firstReady != null) {
+            try {
+                firstReady.await(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        if (backgroundFailure != null) {
+            throw new IllegalStateException(
+                    "Split computation failed for " + name + " — refusing to emit partial splits",
+                    backgroundFailure);
+        }
+
+        List<JdbcSourceSplit> splits = new ArrayList<>();
+        T item;
+        while ((item = outputQueue.poll()) != null) {
+            splits.add(toSplit(item));
+        }
+        return splits;
+    }
+
+    @Override
+    public final void close() {
+        if (executor != null) {
+            executor.shutdownNow();
+            try {
+                if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+                    log.warn(
+                            "Background computation for {} did not stop within the shutdown grace period — a"
+                                    + " query may still be running against its connection.",
+                            name);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        closeResources();
+    }
+
+    @Override
+    public final Serializable serializableState() {
+        return null;
+    }
+
+    @Override
+    public final SplitterEnumerator restoreState(Serializable state) {
+        return this;
+    }
+}

--- a/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/source/enumerator/splitter/snapshot/DatabaseSplitterEnumerator.java
+++ b/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/source/enumerator/splitter/snapshot/DatabaseSplitterEnumerator.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain.Table;
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain.TableColumn;
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain.TableId;
+import org.apache.flink.connector.jdbc.core.datastream.source.split.JdbcSourceSplit;
+import org.apache.flink.connector.jdbc.datasource.connections.JdbcConnectionProvider;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
+
+/** Splitter enumerator that fans out over every table in a database/schema. */
+@PublicEvolving
+public class DatabaseSplitterEnumerator extends AsyncSnapshotSplitterEnumerator<JdbcSourceSplit> {
+
+    private final String catalog;
+    private final String schema;
+    private final Set<String> tables;
+    private final Set<String> lineageQueries;
+    private final int chunkSize;
+
+    // Bound concurrent table splitters so we don't exhaust the connection pool.
+    // Must be <= pool max size in ConnectionProvider.
+    private static final int MAX_CONCURRENT_TABLE_SPLITTERS = 4;
+
+    private transient Queue<TableSplitterEnumerator> pendingTableSplitters;
+    private transient List<TableSplitterEnumerator> activeTableSplitters;
+
+    public DatabaseSplitterEnumerator(
+            String catalog, String schema, Set<String> tables, int chunkSize) {
+        super(schema);
+        this.catalog = catalog;
+        this.schema = schema;
+        this.tables = tables;
+        this.lineageQueries = new LinkedHashSet<>();
+        this.chunkSize = chunkSize;
+    }
+
+    public static DatabaseSplitterEnumeratorBuilder builder() {
+        return new DatabaseSplitterEnumeratorBuilder();
+    }
+
+    @Override
+    public void start(JdbcConnectionProvider connectionProvider) {
+        initConnection(connectionProvider);
+        this.pendingTableSplitters = new ConcurrentLinkedQueue<>();
+        this.activeTableSplitters = new CopyOnWriteArrayList<>();
+        prepareTableSplitters();
+        startBackgroundWork();
+    }
+
+    @Override
+    public List<String> lineageQueries() {
+        return new ArrayList<>(this.lineageQueries);
+    }
+
+    @Override
+    protected void runBackgroundWork() throws InterruptedException {
+        // Start an initial batch of table splitters — each one borrows its
+        // own pooled connection. We refill below as splitters finish so we
+        // never exceed the pool capacity.
+        fillActiveTableSplitters();
+
+        while (!Thread.currentThread().isInterrupted()
+                && (!activeTableSplitters.isEmpty() || !pendingTableSplitters.isEmpty())) {
+            boolean producedSplits = false;
+            List<TableSplitterEnumerator> finished = new ArrayList<>();
+
+            for (TableSplitterEnumerator tableSplitter : activeTableSplitters) {
+                if (tableSplitter.isAllSplitsFinished()) {
+                    lineageQueries.addAll(tableSplitter.lineageQueries());
+                    tableSplitter.close();
+                    finished.add(tableSplitter);
+                    continue;
+                }
+
+                List<JdbcSourceSplit> splits = tableSplitter.enumerateSplits();
+                if (!splits.isEmpty()) {
+                    offerAll(splits);
+                    producedSplits = true;
+                }
+            }
+
+            // CopyOnWriteArrayList's iterator doesn't support remove(); batch-remove instead.
+            if (!finished.isEmpty()) {
+                activeTableSplitters.removeAll(finished);
+            }
+
+            // Refill active set with pending splitters now that finished
+            // ones have returned their connections to the pool.
+            fillActiveTableSplitters();
+
+            if (!producedSplits) {
+                Thread.sleep(100);
+            }
+        }
+    }
+
+    @Override
+    protected JdbcSourceSplit toSplit(JdbcSourceSplit item) {
+        return item;
+    }
+
+    @Override
+    protected void closeResources() {
+        if (activeTableSplitters == null) {
+            return;
+        }
+        for (TableSplitterEnumerator tableSplitter : activeTableSplitters) {
+            tableSplitter.close();
+        }
+        activeTableSplitters.clear();
+        // Do NOT close the main connection — it is managed by the caller (JdbcSourceEnumerator).
+        // Table splitters close their own pooled connections in their close() method.
+    }
+
+    private void fillActiveTableSplitters() {
+        while (activeTableSplitters.size() < MAX_CONCURRENT_TABLE_SPLITTERS) {
+            TableSplitterEnumerator tableSplitter = pendingTableSplitters.poll();
+            if (tableSplitter == null) {
+                return;
+            }
+            // Each table splitter gets its own pooled connection so they can
+            // run concurrently without JDBC thread-safety issues.
+            tableSplitter.start(connection.newInstance());
+            activeTableSplitters.add(tableSplitter);
+        }
+    }
+
+    private void prepareTableSplitters() {
+        Set<Table> dbTablesWithPartition = this.connection.getTables(this.catalog, this.schema);
+        Set<Table> tablesToProcess = new HashSet<>();
+
+        for (Table table : dbTablesWithPartition) {
+            if (tables == null
+                    || tables.isEmpty()
+                    || tables.contains(table.tableId().tableName())) {
+                tablesToProcess.add(table);
+            } else {
+                Set<String> partitions =
+                        table.partitions().stream()
+                                .filter(tables::contains)
+                                .collect(Collectors.toSet());
+
+                if (!partitions.isEmpty()) {
+                    tablesToProcess.add(new Table(table.tableId(), partitions));
+                }
+            }
+        }
+
+        if (tablesToProcess.isEmpty()) {
+            throw new IllegalStateException(
+                    String.format(
+                            "No tables found in the database for catalog: %s, schema: %s, with specified tables: %s",
+                            this.catalog, this.schema, this.tables));
+        }
+
+        for (Table table : tablesToProcess) {
+            Set<String> tableColumns =
+                    this.connection.getTableColumns(table.tableId()).stream()
+                            .map(TableColumn::columnName)
+                            .collect(Collectors.toSet());
+
+            Set<TableId> partitions =
+                    table.partitions().stream()
+                            .map(
+                                    p ->
+                                            TableId.builder()
+                                                    .withCatalogName(table.tableId().catalogName())
+                                                    .withSchemaName(table.tableId().schemaName())
+                                                    .withTableName(p)
+                                                    .build())
+                            .collect(Collectors.toSet());
+
+            if (partitions.isEmpty()) {
+                partitions = Collections.singleton(table.tableId());
+            }
+
+            partitions.stream()
+                    .sorted(Comparator.comparing(TableId::toString))
+                    .forEach(
+                            tableId -> {
+                                TableSplitterEnumerator tableSplitter =
+                                        new TableSplitterEnumerator(
+                                                tableId, tableColumns, chunkSize);
+                                pendingTableSplitters.add(tableSplitter);
+                            });
+        }
+    }
+}

--- a/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/source/enumerator/splitter/snapshot/DatabaseSplitterEnumeratorBuilder.java
+++ b/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/source/enumerator/splitter/snapshot/DatabaseSplitterEnumeratorBuilder.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/** Builder for creating instances of {@link DatabaseSplitterEnumerator}. */
+@PublicEvolving
+public class DatabaseSplitterEnumeratorBuilder {
+
+    private String catalogName;
+    private String schemaName;
+    private final Set<String> tableNames;
+    private int chunkSize;
+
+    protected DatabaseSplitterEnumeratorBuilder() {
+        this.tableNames = new LinkedHashSet<>();
+        this.chunkSize = 100_000;
+    }
+
+    public DatabaseSplitterEnumeratorBuilder withCatalogName(String catalogName) {
+        this.catalogName = catalogName;
+        return this;
+    }
+
+    public DatabaseSplitterEnumeratorBuilder withSchemaName(String schemaName) {
+        this.schemaName = schemaName;
+        return this;
+    }
+
+    public DatabaseSplitterEnumeratorBuilder withTableNames(String... tableName) {
+        withTableNames(new LinkedHashSet<>(Arrays.asList(tableName)));
+        return this;
+    }
+
+    public DatabaseSplitterEnumeratorBuilder withTableNames(Set<String> tableNames) {
+        this.tableNames.addAll(tableNames);
+        return this;
+    }
+
+    public DatabaseSplitterEnumeratorBuilder withChunkSize(int chunkSize) {
+        if (chunkSize <= 0) {
+            throw new IllegalArgumentException(
+                    "chunkSize must be greater than 0 (rows per split), but was: " + chunkSize);
+        }
+        this.chunkSize = chunkSize;
+        return this;
+    }
+
+    public DatabaseSplitterEnumerator build() {
+        return new DatabaseSplitterEnumerator(
+                this.catalogName, this.schemaName, this.tableNames, this.chunkSize);
+    }
+}

--- a/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/source/enumerator/splitter/snapshot/TableSplitterEnumerator.java
+++ b/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/source/enumerator/splitter/snapshot/TableSplitterEnumerator.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.SplitterEnumerator;
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain.TableBounds;
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain.TableColumn;
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain.TableId;
+import org.apache.flink.connector.jdbc.core.datastream.source.split.CheckpointedOffset;
+import org.apache.flink.connector.jdbc.core.datastream.source.split.JdbcSourceSplit;
+import org.apache.flink.connector.jdbc.datasource.connections.JdbcConnectionProvider;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * An implementation of {@link SplitterEnumerator} that splits a table into multiple splits based on
+ * the primary key column and a specified chunk size.
+ */
+@PublicEvolving
+public class TableSplitterEnumerator extends AsyncSnapshotSplitterEnumerator<TableBounds> {
+    private final Logger log = LoggerFactory.getLogger(TableSplitterEnumerator.class);
+
+    private final TableId tableId;
+    private final Set<String> columnNames;
+    private final int chunkSize;
+
+    private TableColumn tablePrimaryKey;
+    private final Set<String> lineageQueries;
+
+    private TableBounds tableMinMax;
+    private Object currentLowerBound;
+    private boolean boundsInitialized;
+
+    protected TableSplitterEnumerator(TableId tableId, Set<String> columnNames, int chunkSize) {
+        super(tableId.toString());
+        this.tableId = tableId;
+        this.columnNames = columnNames;
+        this.chunkSize = chunkSize;
+        this.lineageQueries = new LinkedHashSet<>();
+        this.boundsInitialized = false;
+    }
+
+    public static TableSplitterEnumeratorBuilder builder() {
+        return new TableSplitterEnumeratorBuilder();
+    }
+
+    @Override
+    public void start(JdbcConnectionProvider connectionProvider) {
+        initConnection(connectionProvider);
+        startBackgroundWork();
+    }
+
+    @Override
+    public List<String> lineageQueries() {
+        return new ArrayList<>(lineageQueries);
+    }
+
+    @Override
+    protected void runBackgroundWork() {
+        validateTableAndColumns();
+        if (!boundsInitialized) {
+            return;
+        }
+        while (computeNextBound()) {
+            // offer() inside computeNextBound() already signals readiness per item
+        }
+    }
+
+    @Override
+    protected void closeResources() {
+        // Close this splitter's own pooled connection, returning it to the pool.
+        if (this.connection != null) {
+            this.connection.closeConnection();
+        }
+    }
+
+    private void validateTableAndColumns() {
+        Set<TableColumn> discoveredColumns = connection.getTableColumns(tableId);
+
+        Set<TableColumn> tableColumns;
+        if (this.columnNames.isEmpty()) {
+            tableColumns = discoveredColumns;
+            this.columnNames.addAll(
+                    tableColumns.stream().map(TableColumn::columnName).collect(Collectors.toSet()));
+        } else {
+            tableColumns =
+                    discoveredColumns.stream()
+                            .filter(col -> columnNames.contains(col.columnName()))
+                            .collect(Collectors.toSet());
+        }
+
+        if (tableColumns.size() != columnNames.size()) {
+            Set<String> missingColumns =
+                    columnNames.stream()
+                            .filter(
+                                    colName ->
+                                            tableColumns.stream()
+                                                    .noneMatch(
+                                                            tableCol ->
+                                                                    tableCol.columnName()
+                                                                            .equals(colName)))
+                            .collect(Collectors.toSet());
+            throw new IllegalArgumentException(
+                    String.format(
+                            "These column names %s do not exist in table %s.",
+                            missingColumns, tableId));
+        }
+
+        Set<TableColumn> primaryKeys =
+                tableColumns.stream()
+                        .filter(TableColumn::columnPrimaryKey)
+                        .sorted(Comparator.comparingInt(TableColumn::columnPosition))
+                        .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        if (primaryKeys.isEmpty()) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Table %s does not have a primary key or is not inside columns fields provided."
+                                    + " Snapshot reading requires a primary key to chunk the table.",
+                            tableId));
+        }
+        if (primaryKeys.size() > 1) {
+            log.warn("Table {} has a composite primary key, using only the first field.", tableId);
+        }
+
+        this.tablePrimaryKey = primaryKeys.iterator().next();
+        this.tableMinMax = connection.queryMinMax(tableId, tablePrimaryKey);
+
+        if (tableMinMax.isEmpty()) {
+            log.info("Table {} is empty, single unbounded split generated.", tableId);
+            offer(tableMinMax);
+            return;
+        }
+
+        if (Objects.equals(tableMinMax.lowerBound(), tableMinMax.upperBound())) {
+            log.info("Table {} has only one row, single split generated.", tableId);
+            offer(TableBounds.empty());
+            return;
+        }
+
+        this.currentLowerBound = tableMinMax.lowerBound();
+        this.boundsInitialized = true;
+    }
+
+    private boolean computeNextBound() {
+        if (!boundsInitialized || Objects.equals(currentLowerBound, tableMinMax.upperBound())) {
+            return false;
+        }
+
+        Optional<Object> nextChunk =
+                connection.queryNextChunkMax(
+                        tableId, tablePrimaryKey, currentLowerBound, chunkSize);
+        Object nextUpperBound = nextChunk.orElse(tableMinMax.upperBound());
+        TableBounds splitBounds = TableBounds.of(currentLowerBound, nextUpperBound);
+
+        if (splitBounds.lowerBound().equals(tableMinMax.lowerBound())) {
+            offer(TableBounds.of(null, tableMinMax.lowerBound()));
+        }
+        offer(splitBounds);
+        if (splitBounds.upperBound().equals(tableMinMax.upperBound())) {
+            offer(TableBounds.of(tableMinMax.upperBound(), null));
+        }
+        currentLowerBound = nextUpperBound;
+        return !Objects.equals(currentLowerBound, tableMinMax.upperBound());
+    }
+
+    @Override
+    protected JdbcSourceSplit toSplit(TableBounds bound) {
+        String splitId =
+                String.format(
+                        "%s:%s:%s:%s",
+                        tableId.catalogName(),
+                        tableId.schemaName(),
+                        tableId.tableName(),
+                        bound.toString());
+        String splitQuery =
+                this.connection.createQueryWithBounds(tableId, columnNames, tablePrimaryKey, bound);
+        Serializable[] splitParams = bound.getBoundsAsParams();
+        JdbcSourceSplit split =
+                new JdbcSourceSplit(splitId, splitQuery, splitParams, new CheckpointedOffset());
+        log.info("Generated split: {}", split);
+        lineageQueries.add(splitQuery);
+        return split;
+    }
+}

--- a/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/source/enumerator/splitter/snapshot/TableSplitterEnumeratorBuilder.java
+++ b/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/source/enumerator/splitter/snapshot/TableSplitterEnumeratorBuilder.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain.TableId;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/** Builder for creating instances of {@link TableSplitterEnumerator}. */
+@PublicEvolving
+public class TableSplitterEnumeratorBuilder {
+
+    private String catalogName;
+    private String schemaName;
+    private String tableName;
+    private int chunkSize;
+    private final Set<String> columnNames;
+
+    protected TableSplitterEnumeratorBuilder() {
+        this.columnNames = new LinkedHashSet<>();
+        this.chunkSize = 100_000;
+    }
+
+    public TableSplitterEnumeratorBuilder withCatalogName(String catalogName) {
+        this.catalogName = catalogName;
+        return this;
+    }
+
+    public TableSplitterEnumeratorBuilder withSchemaName(String schemaName) {
+        this.schemaName = schemaName;
+        return this;
+    }
+
+    public TableSplitterEnumeratorBuilder withTableName(String tableName) {
+        this.tableName = tableName;
+        return this;
+    }
+
+    public TableSplitterEnumeratorBuilder withColumnNames(String... columnName) {
+        return withColumnNames(new LinkedHashSet<>(Arrays.asList(columnName)));
+    }
+
+    public TableSplitterEnumeratorBuilder withColumnNames(Set<String> columnNames) {
+        this.columnNames.addAll(columnNames);
+        return this;
+    }
+
+    public TableSplitterEnumeratorBuilder withChunkSize(int chunkSize) {
+        if (chunkSize <= 0) {
+            throw new IllegalArgumentException(
+                    "chunkSize must be greater than 0 (rows per split), but was: " + chunkSize);
+        }
+        this.chunkSize = chunkSize;
+        return this;
+    }
+
+    public TableSplitterEnumerator build() {
+        return new TableSplitterEnumerator(
+                new TableId(this.catalogName, this.schemaName, this.tableName),
+                this.columnNames,
+                this.chunkSize);
+    }
+}

--- a/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/source/enumerator/splitter/snapshot/domain/Table.java
+++ b/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/source/enumerator/splitter/snapshot/domain/Table.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.Set;
+
+/** Represents a table together with the set of partition names discovered for it, if any. */
+@PublicEvolving
+public class Table implements Serializable {
+
+    private final TableId tableId;
+    private final Set<String> partitions;
+
+    public Table(TableId tableId, Set<String> partitions) {
+        this.tableId = tableId;
+        this.partitions = partitions;
+    }
+
+    public TableId tableId() {
+        return tableId;
+    }
+
+    public Set<String> partitions() {
+        return partitions;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Table)) {
+            return false;
+        }
+        Table that = (Table) o;
+        return Objects.equals(tableId, that.tableId) && Objects.equals(partitions, that.partitions);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tableId, partitions);
+    }
+
+    @Override
+    public String toString() {
+        return "Table{" + "tableId=" + tableId + ", partitions=" + partitions + '}';
+    }
+}

--- a/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/source/enumerator/splitter/snapshot/domain/TableBounds.java
+++ b/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/source/enumerator/splitter/snapshot/domain/TableBounds.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.StringJoiner;
+
+/** Represents the bounds of a table split with lower and upper bound values. */
+@PublicEvolving
+public class TableBounds implements Serializable {
+
+    private final Object lowerBound;
+    private final Object upperBound;
+
+    public TableBounds(Object lowerBound, Object upperBound) {
+        this.lowerBound = lowerBound;
+        this.upperBound = upperBound;
+    }
+
+    public Object lowerBound() {
+        return lowerBound;
+    }
+
+    public Object upperBound() {
+        return upperBound;
+    }
+
+    public static TableBounds of(Object lowerBound, Object upperBound) {
+        return new TableBounds(lowerBound, upperBound);
+    }
+
+    public static TableBounds empty() {
+        return new TableBounds(null, null);
+    }
+
+    public boolean isEmpty() {
+        return lowerBound == null && upperBound == null;
+    }
+
+    public Serializable[] getBoundsAsParams() {
+        if (isEmpty()) {
+            return null;
+        }
+
+        List<Serializable> list = new ArrayList<>();
+        if (lowerBound != null) {
+            list.add((Serializable) lowerBound);
+        }
+        if (upperBound != null) {
+            list.add((Serializable) upperBound);
+        }
+
+        return list.toArray(new Serializable[0]);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof TableBounds)) {
+            return false;
+        }
+        TableBounds that = (TableBounds) o;
+        return Objects.equals(lowerBound, that.lowerBound)
+                && Objects.equals(upperBound, that.upperBound);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(lowerBound, upperBound);
+    }
+
+    @Override
+    public String toString() {
+        if (isEmpty()) {
+            return "[]";
+        }
+        return new StringJoiner(",", "[", "]")
+                .add(lowerBound == null ? "" : lowerBound.toString())
+                .add(upperBound == null ? "" : upperBound.toString())
+                .toString();
+    }
+}

--- a/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/source/enumerator/splitter/snapshot/domain/TableColumn.java
+++ b/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/source/enumerator/splitter/snapshot/domain/TableColumn.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/** Represents a column in a database table with its metadata. */
+@PublicEvolving
+public class TableColumn implements Serializable {
+
+    private final Integer columnPosition;
+    private final String columnName;
+    private final String columnType;
+    private final Boolean columnNullable;
+    private final Boolean columnPrimaryKey;
+
+    public TableColumn(
+            Integer columnPosition,
+            String columnName,
+            String columnType,
+            Boolean columnNullable,
+            Boolean columnPrimaryKey) {
+        this.columnPosition = columnPosition;
+        this.columnName = columnName;
+        this.columnType = columnType;
+        this.columnNullable = columnNullable;
+        this.columnPrimaryKey = columnPrimaryKey;
+    }
+
+    public Integer columnPosition() {
+        return columnPosition;
+    }
+
+    public String columnName() {
+        return columnName;
+    }
+
+    public String columnType() {
+        return columnType;
+    }
+
+    public Boolean columnNullable() {
+        return columnNullable;
+    }
+
+    public Boolean columnPrimaryKey() {
+        return columnPrimaryKey;
+    }
+
+    public boolean isUuidColumnType() {
+        return "UUID".equalsIgnoreCase(columnType);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof TableColumn)) {
+            return false;
+        }
+        TableColumn that = (TableColumn) o;
+        return Objects.equals(columnPosition, that.columnPosition)
+                && Objects.equals(columnName, that.columnName)
+                && Objects.equals(columnType, that.columnType)
+                && Objects.equals(columnNullable, that.columnNullable)
+                && Objects.equals(columnPrimaryKey, that.columnPrimaryKey);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                columnPosition, columnName, columnType, columnNullable, columnPrimaryKey);
+    }
+
+    @Override
+    public String toString() {
+        return "TableColumn{"
+                + "columnPosition="
+                + columnPosition
+                + ", columnName='"
+                + columnName
+                + '\''
+                + ", columnType='"
+                + columnType
+                + '\''
+                + ", columnNullable="
+                + columnNullable
+                + ", columnPrimaryKey="
+                + columnPrimaryKey
+                + '}';
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Builder class for constructing TableColumn instances. */
+    public static class Builder {
+        private String columnName;
+        private String columnType;
+        private Integer columnPosition;
+        private Boolean columnNullable;
+        private Boolean columnPrimaryKey;
+
+        Builder() {}
+
+        public Builder withColumnName(String columnName) {
+            this.columnName = columnName;
+            return this;
+        }
+
+        public Builder withColumnType(String columnType) {
+            this.columnType = columnType;
+            return this;
+        }
+
+        public Builder withColumnPosition(Integer columnPosition) {
+            this.columnPosition = columnPosition;
+            return this;
+        }
+
+        public Builder withColumnNullable(Boolean isNullable) {
+            this.columnNullable = isNullable;
+            return this;
+        }
+
+        public Builder withColumnPk(Boolean isPk) {
+            this.columnPrimaryKey = isPk;
+            return this;
+        }
+
+        public TableColumn build() {
+            return new TableColumn(
+                    this.columnPosition,
+                    this.columnName,
+                    this.columnType,
+                    this.columnNullable,
+                    this.columnPrimaryKey);
+        }
+    }
+}

--- a/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/source/enumerator/splitter/snapshot/domain/TableId.java
+++ b/flink-connector-jdbc-core/src/main/java/org/apache/flink/connector/jdbc/core/datastream/source/enumerator/splitter/snapshot/domain/TableId.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Represents a unique identifier for a database table, including catalog name, schema name, and
+ * table name.
+ */
+@PublicEvolving
+public class TableId implements Serializable {
+
+    private final String catalogName;
+    private final String schemaName;
+    private final String tableName;
+
+    public TableId(String catalogName, String schemaName, String tableName) {
+        this.catalogName = checkNotNull(catalogName, "Catalog name cannot be null");
+        this.schemaName = checkNotNull(schemaName, "Schema name cannot be null");
+        this.tableName = checkNotNull(tableName, "Table name cannot be null");
+    }
+
+    public String catalogName() {
+        return catalogName;
+    }
+
+    public String schemaName() {
+        return schemaName;
+    }
+
+    public String tableName() {
+        return tableName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof TableId)) {
+            return false;
+        }
+        TableId that = (TableId) o;
+        return Objects.equals(catalogName, that.catalogName)
+                && Objects.equals(schemaName, that.schemaName)
+                && Objects.equals(tableName, that.tableName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(catalogName, schemaName, tableName);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s.%s.%s", catalogName, schemaName, tableName);
+    }
+
+    public static TableIdBuilder builder() {
+        return new TableIdBuilder();
+    }
+
+    /** Builder class for constructing {@link TableId} instances. */
+    public static class TableIdBuilder {
+        private String catalogName;
+        private String schemaName;
+        private String tableName;
+
+        protected TableIdBuilder() {}
+
+        public TableIdBuilder withCatalogName(String catalogName) {
+            this.catalogName = catalogName;
+            return this;
+        }
+
+        public TableIdBuilder withSchemaName(String schemaName) {
+            this.schemaName = schemaName;
+            return this;
+        }
+
+        public TableIdBuilder withTableName(String tableName) {
+            this.tableName = tableName;
+            return this;
+        }
+
+        public TableId build() {
+            return new TableId(this.catalogName, this.schemaName, this.tableName);
+        }
+    }
+}

--- a/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/datastream/connection/AbstractConnectionProviderTest.java
+++ b/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/datastream/connection/AbstractConnectionProviderTest.java
@@ -1,0 +1,345 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.core.datastream.connection;
+
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain.Table;
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain.TableBounds;
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain.TableColumn;
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain.TableId;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AbstractConnectionProviderTest {
+
+    private static final AtomicInteger DB_COUNTER = new AtomicInteger();
+
+    @Test
+    void testConstructorEstablishesConnectionButDoesNotInvokeHook() {
+        TestConnectionProvider provider = newTestProvider();
+        try {
+            assertThat(provider.getConnection()).isNotNull();
+            // The constructor bypasses onConnectionEstablished() on purpose: at this point a
+            // subclass's own fields aren't initialized yet, so invoking an overridable hook here
+            // would run against half-constructed state.
+            assertThat(provider.onConnectionEstablishedCalls).hasValue(0);
+        } finally {
+            provider.closeConnection();
+        }
+    }
+
+    @Test
+    void testGetOrEstablishConnectionInvokesHookAndReusesValidConnection() throws Exception {
+        TestConnectionProvider provider = newTestProvider();
+        try {
+            Connection first = provider.getOrEstablishConnection();
+            Connection second = provider.getOrEstablishConnection();
+
+            assertThat(second).isSameAs(first);
+            assertThat(provider.onConnectionEstablishedCalls).hasValue(2);
+        } finally {
+            provider.closeConnection();
+        }
+    }
+
+    @Test
+    void testReestablishConnectionClosesOldAndOpensNew() throws Exception {
+        TestConnectionProvider provider = newTestProvider();
+        try {
+            Connection first = provider.getConnection();
+            Connection second = provider.reestablishConnection();
+
+            assertThat(second).isNotSameAs(first);
+            assertThat(first.isClosed()).isTrue();
+            assertThat(provider.isConnectionValid()).isTrue();
+        } finally {
+            provider.closeConnection();
+        }
+    }
+
+    @Test
+    void testCloseConnectionIsIdempotentAndInvalidatesConnection() throws Exception {
+        TestConnectionProvider provider = newTestProvider();
+
+        provider.closeConnection();
+
+        assertThat(provider.isConnectionValid()).isFalse();
+        assertThat(provider.getConnection()).isNull();
+
+        provider.closeConnection();
+    }
+
+    @Test
+    void testConstructorThrowsConnectionExceptionWhenNoDriverAcceptsUrl() throws SQLException {
+        NullConnectingDriver driver = new NullConnectingDriver();
+        DriverManager.registerDriver(driver);
+        try {
+            ConnectionOptions options =
+                    ConnectionOptions.builder()
+                            .withUrl("jdbc:h2:mem:" + uniqueDbName())
+                            .withDriverName(driver.getClass().getName())
+                            .build();
+
+            assertThatThrownBy(() -> new TestConnectionProvider(options))
+                    .isInstanceOf(ConnectionException.class)
+                    .hasMessageContaining("Failed to establish initial connection")
+                    .cause()
+                    .hasMessageContaining("No suitable driver found");
+        } finally {
+            DriverManager.deregisterDriver(driver);
+        }
+    }
+
+    @Test
+    void testGetTableColumnsReturnsRealMetadataWithPrimaryKeyFlag() throws Exception {
+        TestConnectionProvider provider = newTestProvider();
+        try {
+            Connection connection = provider.getConnection();
+            try (Statement statement = connection.createStatement()) {
+                statement.execute(
+                        "CREATE TABLE ITEMS (ID BIGINT PRIMARY KEY, NAME VARCHAR(50) NOT NULL)");
+            }
+            TableId tableId =
+                    TableId.builder()
+                            .withCatalogName(connection.getCatalog())
+                            .withSchemaName(connection.getSchema())
+                            .withTableName("ITEMS")
+                            .build();
+
+            Set<TableColumn> columns = provider.getTableColumns(tableId);
+
+            assertThat(columns).hasSize(2);
+            TableColumn idColumn =
+                    columns.stream()
+                            .filter(c -> "ID".equals(c.columnName()))
+                            .findFirst()
+                            .orElseThrow(AssertionError::new);
+            assertThat(idColumn.columnPrimaryKey()).isTrue();
+            assertThat(idColumn.columnPosition()).isEqualTo(1);
+            assertThat(idColumn.columnNullable()).isFalse();
+
+            TableColumn nameColumn =
+                    columns.stream()
+                            .filter(c -> "NAME".equals(c.columnName()))
+                            .findFirst()
+                            .orElseThrow(AssertionError::new);
+            assertThat(nameColumn.columnPrimaryKey()).isFalse();
+            assertThat(nameColumn.columnNullable()).isFalse();
+        } finally {
+            provider.closeConnection();
+        }
+    }
+
+    @Test
+    void testQueryAndMapExecutesQueryAndAppliesMapper() {
+        TestConnectionProvider provider = newTestProvider();
+        try {
+            Integer result =
+                    provider.queryAndMap(
+                            "SELECT 42",
+                            rs -> {
+                                rs.next();
+                                return rs.getInt(1);
+                            });
+
+            assertThat(result).isEqualTo(42);
+        } finally {
+            provider.closeConnection();
+        }
+    }
+
+    @Test
+    void testPrepareQueryAndMapBindsParametersAndReusesCachedStatement() throws Exception {
+        TestConnectionProvider provider = newTestProvider();
+        try {
+            try (Statement statement = provider.getConnection().createStatement()) {
+                statement.execute("CREATE TABLE T (ID INT)");
+                statement.execute("INSERT INTO T VALUES (1), (2), (3)");
+            }
+
+            Integer count =
+                    provider.prepareQueryAndMap(
+                            "SELECT COUNT(*) FROM T WHERE ID > ?",
+                            ps -> ps.setInt(1, 1),
+                            rs -> {
+                                rs.next();
+                                return rs.getInt(1);
+                            });
+            assertThat(count).isEqualTo(2);
+
+            // Re-run the same query text a second time to exercise the prepared-statement cache.
+            Integer countAgain =
+                    provider.prepareQueryAndMap(
+                            "SELECT COUNT(*) FROM T WHERE ID > ?",
+                            ps -> ps.setInt(1, 0),
+                            rs -> {
+                                rs.next();
+                                return rs.getInt(1);
+                            });
+            assertThat(countAgain).isEqualTo(3);
+        } finally {
+            provider.closeConnection();
+        }
+    }
+
+    @Test
+    void testWithQueryTimeoutRejectsZeroNegativeAndNullDurations() {
+        TestConnectionProvider provider = newTestProvider();
+        try {
+            assertThatThrownBy(() -> provider.withQueryTimeout(Duration.ZERO))
+                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> provider.withQueryTimeout(Duration.ofSeconds(-1)))
+                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> provider.withQueryTimeout(null))
+                    .isInstanceOf(NullPointerException.class);
+        } finally {
+            provider.closeConnection();
+        }
+    }
+
+    @Test
+    void testMaxPoolSizeAndPoolNameDefaults() {
+        TestConnectionProvider provider = newTestProvider();
+        try {
+            assertThat(provider.maxPoolSize()).isEqualTo(4);
+            assertThat(provider.poolName()).isEqualTo("TestConnectionProvider-pool");
+        } finally {
+            provider.closeConnection();
+        }
+    }
+
+    @Test
+    void testGetOrCreatePoolCreatesPoolLazilyAndMemoizes() {
+        TestConnectionProvider provider = newTestProvider();
+        try {
+            HikariDataSource first = provider.getOrCreatePool();
+            HikariDataSource second = provider.getOrCreatePool();
+
+            assertThat(first).isSameAs(second);
+            assertThat(first.getMaximumPoolSize()).isEqualTo(4);
+            assertThat(first.isClosed()).isFalse();
+        } finally {
+            provider.closeConnection();
+        }
+    }
+
+    @Test
+    void testCloseConnectionShutsDownOwnedPool() {
+        TestConnectionProvider provider = newTestProvider();
+        HikariDataSource pool = provider.getOrCreatePool();
+
+        provider.closeConnection();
+
+        assertThat(pool.isClosed()).isTrue();
+    }
+
+    @Test
+    void testPooledConstructorBorrowsFromSharedPoolAndDoesNotOwnIt() throws Exception {
+        TestConnectionProvider owner = newTestProvider();
+        try {
+            HikariDataSource pool = owner.getOrCreatePool();
+            TestConnectionProvider borrower = new TestConnectionProvider(owner.jdbcOptions, pool);
+            try {
+                assertThat(borrower.getConnection()).isNotNull();
+                assertThat(borrower.getConnection().isValid(5)).isTrue();
+            } finally {
+                borrower.closeConnection();
+            }
+
+            // The borrower doesn't own the pool, so closing it must not shut the pool down.
+            assertThat(pool.isClosed()).isFalse();
+        } finally {
+            owner.closeConnection();
+        }
+    }
+
+    private static String uniqueDbName() {
+        return "abstract_provider_" + DB_COUNTER.incrementAndGet();
+    }
+
+    private static TestConnectionProvider newTestProvider() {
+        ConnectionOptions options =
+                ConnectionOptions.builder()
+                        .withUrl("jdbc:h2:mem:" + uniqueDbName() + ";DB_CLOSE_DELAY=-1")
+                        .withDriverName("org.h2.Driver")
+                        .build();
+        return new TestConnectionProvider(options);
+    }
+
+    /** Minimal concrete subclass exercising the shared connection lifecycle/pooling machinery. */
+    private static final class TestConnectionProvider extends AbstractConnectionProvider {
+
+        final AtomicInteger onConnectionEstablishedCalls = new AtomicInteger();
+
+        TestConnectionProvider(ConnectionOptions jdbcOptions) {
+            super(jdbcOptions);
+        }
+
+        TestConnectionProvider(ConnectionOptions jdbcOptions, HikariDataSource pool) {
+            super(jdbcOptions, pool);
+        }
+
+        @Override
+        protected void onConnectionEstablished() {
+            onConnectionEstablishedCalls.incrementAndGet();
+        }
+
+        @Override
+        public Set<Table> getTables(String catalog, String schema) {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public String createQueryWithBounds(
+                TableId tableId,
+                Set<String> tableColumns,
+                TableColumn pkColumn,
+                TableBounds bounds) {
+            return "";
+        }
+
+        @Override
+        public TableBounds queryMinMax(TableId tableId, TableColumn column) {
+            return TableBounds.empty();
+        }
+
+        @Override
+        public Optional<Object> queryNextChunkMax(
+                TableId tableId, TableColumn column, Object lowerBound, long chunkSize) {
+            return Optional.empty();
+        }
+
+        @Override
+        public ConnectionProvider newInstance() {
+            return new TestConnectionProvider(jdbcOptions, getOrCreatePool());
+        }
+    }
+}

--- a/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/datastream/connection/AbstractConnectionProviderTest.java
+++ b/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/datastream/connection/AbstractConnectionProviderTest.java
@@ -1,0 +1,372 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.core.datastream.connection;
+
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain.Table;
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain.TableBounds;
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain.TableColumn;
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain.TableId;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AbstractConnectionProviderTest {
+
+    private static final AtomicInteger DB_COUNTER = new AtomicInteger();
+
+    @Test
+    void testConstructorEstablishesConnectionButDoesNotInvokeHook() {
+        TestConnectionProvider provider = newTestProvider();
+        try {
+            assertThat(provider.getConnection()).isNotNull();
+            // The constructor bypasses onConnectionEstablished() on purpose: at this point a
+            // subclass's own fields aren't initialized yet, so invoking an overridable hook here
+            // would run against half-constructed state.
+            assertThat(provider.onConnectionEstablishedCalls).hasValue(0);
+        } finally {
+            provider.closeConnection();
+        }
+    }
+
+    @Test
+    void testGetOrEstablishConnectionInvokesHookAndReusesValidConnection() throws Exception {
+        TestConnectionProvider provider = newTestProvider();
+        try {
+            Connection first = provider.getOrEstablishConnection();
+            Connection second = provider.getOrEstablishConnection();
+
+            assertThat(second).isSameAs(first);
+            assertThat(provider.onConnectionEstablishedCalls).hasValue(2);
+        } finally {
+            provider.closeConnection();
+        }
+    }
+
+    @Test
+    void testReestablishConnectionClosesOldAndOpensNew() throws Exception {
+        TestConnectionProvider provider = newTestProvider();
+        try {
+            Connection first = provider.getConnection();
+            Connection second = provider.reestablishConnection();
+
+            assertThat(second).isNotSameAs(first);
+            assertThat(first.isClosed()).isTrue();
+            assertThat(provider.isConnectionValid()).isTrue();
+        } finally {
+            provider.closeConnection();
+        }
+    }
+
+    @Test
+    void testCloseConnectionIsIdempotentAndInvalidatesConnection() throws Exception {
+        TestConnectionProvider provider = newTestProvider();
+
+        provider.closeConnection();
+
+        assertThat(provider.isConnectionValid()).isFalse();
+        assertThat(provider.getConnection()).isNull();
+
+        provider.closeConnection();
+    }
+
+    @Test
+    void testConstructorThrowsConnectionExceptionWhenNoDriverAcceptsUrl() throws SQLException {
+        NullConnectingDriver driver = new NullConnectingDriver();
+        DriverManager.registerDriver(driver);
+        try {
+            ConnectionOptions options =
+                    ConnectionOptions.builder()
+                            .withUrl("jdbc:h2:mem:" + uniqueDbName())
+                            .withDriverName(driver.getClass().getName())
+                            .build();
+
+            assertThatThrownBy(() -> new TestConnectionProvider(options))
+                    .isInstanceOf(ConnectionException.class)
+                    .hasMessageContaining("Failed to establish initial connection")
+                    .cause()
+                    .hasMessageContaining("No suitable driver found");
+        } finally {
+            DriverManager.deregisterDriver(driver);
+        }
+    }
+
+    @Test
+    void testGetTableColumnsReturnsRealMetadataWithPrimaryKeyFlag() throws Exception {
+        TestConnectionProvider provider = newTestProvider();
+        try {
+            Connection connection = provider.getConnection();
+            try (Statement statement = connection.createStatement()) {
+                statement.execute(
+                        "CREATE TABLE ITEMS (ID BIGINT PRIMARY KEY, NAME VARCHAR(50) NOT NULL)");
+            }
+            TableId tableId =
+                    TableId.builder()
+                            .withCatalogName(connection.getCatalog())
+                            .withSchemaName(connection.getSchema())
+                            .withTableName("ITEMS")
+                            .build();
+
+            Set<TableColumn> columns = provider.getTableColumns(tableId);
+
+            assertThat(columns).hasSize(2);
+            TableColumn idColumn =
+                    columns.stream()
+                            .filter(c -> "ID".equals(c.columnName()))
+                            .findFirst()
+                            .orElseThrow(AssertionError::new);
+            assertThat(idColumn.columnPrimaryKey()).isTrue();
+            assertThat(idColumn.columnPosition()).isEqualTo(1);
+            assertThat(idColumn.columnNullable()).isFalse();
+
+            TableColumn nameColumn =
+                    columns.stream()
+                            .filter(c -> "NAME".equals(c.columnName()))
+                            .findFirst()
+                            .orElseThrow(AssertionError::new);
+            assertThat(nameColumn.columnPrimaryKey()).isFalse();
+            assertThat(nameColumn.columnNullable()).isFalse();
+        } finally {
+            provider.closeConnection();
+        }
+    }
+
+    @Test
+    void testQueryAndMapExecutesQueryAndAppliesMapper() {
+        TestConnectionProvider provider = newTestProvider();
+        try {
+            Integer result =
+                    provider.queryAndMap(
+                            "SELECT 42",
+                            rs -> {
+                                rs.next();
+                                return rs.getInt(1);
+                            });
+
+            assertThat(result).isEqualTo(42);
+        } finally {
+            provider.closeConnection();
+        }
+    }
+
+    @Test
+    void testPrepareQueryAndMapBindsParametersAndReusesCachedStatement() throws Exception {
+        TestConnectionProvider provider = newTestProvider();
+        try {
+            try (Statement statement = provider.getConnection().createStatement()) {
+                statement.execute("CREATE TABLE T (ID INT)");
+                statement.execute("INSERT INTO T VALUES (1), (2), (3)");
+            }
+
+            Integer count =
+                    provider.prepareQueryAndMap(
+                            "SELECT COUNT(*) FROM T WHERE ID > ?",
+                            ps -> ps.setInt(1, 1),
+                            rs -> {
+                                rs.next();
+                                return rs.getInt(1);
+                            });
+            assertThat(count).isEqualTo(2);
+
+            // Re-run the same query text a second time to exercise the prepared-statement cache.
+            Integer countAgain =
+                    provider.prepareQueryAndMap(
+                            "SELECT COUNT(*) FROM T WHERE ID > ?",
+                            ps -> ps.setInt(1, 0),
+                            rs -> {
+                                rs.next();
+                                return rs.getInt(1);
+                            });
+            assertThat(countAgain).isEqualTo(3);
+        } finally {
+            provider.closeConnection();
+        }
+    }
+
+    @Test
+    void testWithQueryTimeoutRejectsZeroNegativeAndNullDurations() {
+        TestConnectionProvider provider = newTestProvider();
+        try {
+            assertThatThrownBy(() -> provider.withQueryTimeout(Duration.ZERO))
+                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> provider.withQueryTimeout(Duration.ofSeconds(-1)))
+                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> provider.withQueryTimeout(null))
+                    .isInstanceOf(NullPointerException.class);
+        } finally {
+            provider.closeConnection();
+        }
+    }
+
+    @Test
+    void testMaxPoolSizeAndPoolNameDefaults() {
+        TestConnectionProvider provider = newTestProvider();
+        try {
+            assertThat(provider.maxPoolSize()).isEqualTo(4);
+            assertThat(provider.poolName()).isEqualTo("TestConnectionProvider-pool");
+        } finally {
+            provider.closeConnection();
+        }
+    }
+
+    @Test
+    void testGetOrCreatePoolCreatesPoolLazilyAndMemoizes() {
+        TestConnectionProvider provider = newTestProvider();
+        try {
+            HikariDataSource first = provider.getOrCreatePool();
+            HikariDataSource second = provider.getOrCreatePool();
+
+            assertThat(first).isSameAs(second);
+            assertThat(first.getMaximumPoolSize()).isEqualTo(4);
+            assertThat(first.isClosed()).isFalse();
+        } finally {
+            provider.closeConnection();
+        }
+    }
+
+    @Test
+    void testCloseConnectionShutsDownOwnedPool() {
+        TestConnectionProvider provider = newTestProvider();
+        HikariDataSource pool = provider.getOrCreatePool();
+
+        provider.closeConnection();
+
+        assertThat(pool.isClosed()).isTrue();
+    }
+
+    @Test
+    void testPooledConstructorBorrowsFromSharedPoolAndDoesNotOwnIt() throws Exception {
+        TestConnectionProvider owner = newTestProvider();
+        try {
+            HikariDataSource pool = owner.getOrCreatePool();
+            TestConnectionProvider borrower = new TestConnectionProvider(owner.jdbcOptions, pool);
+            try {
+                assertThat(borrower.getConnection()).isNotNull();
+                assertThat(borrower.getConnection().isValid(5)).isTrue();
+            } finally {
+                borrower.closeConnection();
+            }
+
+            // The borrower doesn't own the pool, so closing it must not shut the pool down.
+            assertThat(pool.isClosed()).isFalse();
+        } finally {
+            owner.closeConnection();
+        }
+    }
+
+    @Test
+    void testReestablishOnBorrowedInstanceReBorrowsFromPoolInsteadOfBypassingIt() throws Exception {
+        TestConnectionProvider owner = newTestProvider();
+        try {
+            HikariDataSource pool = owner.getOrCreatePool();
+            TestConnectionProvider borrower = new TestConnectionProvider(owner.jdbcOptions, pool);
+            try {
+                // The initial borrow comes from the pool (HikariCP wraps it in a proxy).
+                assertThat(borrower.getConnection().getClass().getName()).contains("Hikari");
+
+                Connection first = borrower.getConnection();
+                Connection second = borrower.reestablishConnection();
+
+                assertThat(second).isNotSameAs(first);
+                // The reestablished connection must still come from the pool, not a direct driver
+                // connection that bypasses HikariCP.
+                assertThat(second.getClass().getName()).contains("Hikari");
+                assertThat(borrower.isConnectionValid()).isTrue();
+            } finally {
+                borrower.closeConnection();
+            }
+            assertThat(pool.isClosed()).isFalse();
+        } finally {
+            owner.closeConnection();
+        }
+    }
+
+    private static String uniqueDbName() {
+        return "abstract_provider_" + DB_COUNTER.incrementAndGet();
+    }
+
+    private static TestConnectionProvider newTestProvider() {
+        ConnectionOptions options =
+                ConnectionOptions.builder()
+                        .withUrl("jdbc:h2:mem:" + uniqueDbName() + ";DB_CLOSE_DELAY=-1")
+                        .withDriverName("org.h2.Driver")
+                        .build();
+        return new TestConnectionProvider(options);
+    }
+
+    /** Minimal concrete subclass exercising the shared connection lifecycle/pooling machinery. */
+    private static final class TestConnectionProvider extends AbstractConnectionProvider {
+
+        final AtomicInteger onConnectionEstablishedCalls = new AtomicInteger();
+
+        TestConnectionProvider(ConnectionOptions jdbcOptions) {
+            super(jdbcOptions);
+        }
+
+        TestConnectionProvider(ConnectionOptions jdbcOptions, HikariDataSource pool) {
+            super(jdbcOptions, pool);
+        }
+
+        @Override
+        protected void onConnectionEstablished() {
+            onConnectionEstablishedCalls.incrementAndGet();
+        }
+
+        @Override
+        public Set<Table> getTables(String catalog, String schema) {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public String createQueryWithBounds(
+                TableId tableId,
+                Set<String> tableColumns,
+                TableColumn pkColumn,
+                TableBounds bounds) {
+            return "";
+        }
+
+        @Override
+        public TableBounds queryMinMax(TableId tableId, TableColumn column) {
+            return TableBounds.empty();
+        }
+
+        @Override
+        public Optional<Object> queryNextChunkMax(
+                TableId tableId, TableColumn column, Object lowerBound, long chunkSize) {
+            return Optional.empty();
+        }
+
+        @Override
+        public ConnectionProvider newInstance() {
+            return new TestConnectionProvider(jdbcOptions, getOrCreatePool());
+        }
+    }
+}

--- a/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/datastream/connection/ConnectionDataSourceTest.java
+++ b/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/datastream/connection/ConnectionDataSourceTest.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.core.datastream.connection;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ConnectionDataSourceTest {
+
+    @Test
+    void testGetConnectionUsesDriverManagerWhenDriverNameIsNull() throws Exception {
+        ConnectionOptions options =
+                ConnectionOptions.builder().withUrl("jdbc:h2:mem:datasource_no_driver").build();
+        ConnectionDataSource.DriverResolver resolver =
+                () -> {
+                    throw new AssertionError(
+                            "Driver resolver should not be consulted when driverName is null");
+                };
+        ConnectionDataSource dataSource = new ConnectionDataSource(options, resolver);
+
+        try (Connection connection = dataSource.getConnection()) {
+            assertThat(connection.isValid(5)).isTrue();
+        }
+    }
+
+    @Test
+    void testGetConnectionDelegatesToDriverResolverWhenDriverNameIsSet() throws Exception {
+        ConnectionOptions options =
+                ConnectionOptions.builder()
+                        .withUrl("jdbc:h2:mem:datasource_with_driver")
+                        .withDriverName("org.h2.Driver")
+                        .build();
+        AtomicInteger resolveCalls = new AtomicInteger();
+        ConnectionDataSource.DriverResolver resolver =
+                () -> {
+                    resolveCalls.incrementAndGet();
+                    return new org.h2.Driver();
+                };
+        ConnectionDataSource dataSource = new ConnectionDataSource(options, resolver);
+
+        try (Connection connection = dataSource.getConnection()) {
+            assertThat(connection.isValid(5)).isTrue();
+        }
+        assertThat(resolveCalls).hasValue(1);
+    }
+
+    @Test
+    void testGetConnectionWithCredentialsDelegatesToGetConnection() throws Exception {
+        ConnectionOptions options =
+                ConnectionOptions.builder()
+                        .withUrl("jdbc:h2:mem:datasource_with_credentials")
+                        .withDriverName("org.h2.Driver")
+                        .build();
+        AtomicInteger resolveCalls = new AtomicInteger();
+        ConnectionDataSource.DriverResolver resolver =
+                () -> {
+                    resolveCalls.incrementAndGet();
+                    return new org.h2.Driver();
+                };
+        ConnectionDataSource dataSource = new ConnectionDataSource(options, resolver);
+
+        try (Connection connection = dataSource.getConnection("user", "pass")) {
+            assertThat(connection.isValid(5)).isTrue();
+        }
+        assertThat(resolveCalls).hasValue(1);
+    }
+
+    @Test
+    void testGetConnectionThrowsWhenResolvedDriverRejectsUrl() {
+        ConnectionOptions options =
+                ConnectionOptions.builder()
+                        .withUrl("jdbc:h2:mem:datasource_rejected")
+                        .withDriverName("does.not.matter")
+                        .build();
+        ConnectionDataSource dataSource =
+                new ConnectionDataSource(options, NullConnectingDriver::new);
+
+        assertThatThrownBy(dataSource::getConnection)
+                .isInstanceOf(SQLException.class)
+                .hasMessageContaining("No suitable driver found");
+    }
+
+    @Test
+    void testGetConnectionWrapsClassNotFoundExceptionFromResolver() {
+        ConnectionOptions options =
+                ConnectionOptions.builder()
+                        .withUrl("jdbc:h2:mem:datasource_missing_class")
+                        .withDriverName("does.not.exist")
+                        .build();
+        ConnectionDataSource.DriverResolver resolver =
+                () -> {
+                    throw new ClassNotFoundException("does.not.exist");
+                };
+        ConnectionDataSource dataSource = new ConnectionDataSource(options, resolver);
+
+        assertThatThrownBy(dataSource::getConnection)
+                .isInstanceOf(SQLException.class)
+                .hasMessageContaining("Failed to load driver")
+                .hasCauseInstanceOf(ClassNotFoundException.class);
+    }
+
+    @Test
+    void testLogWriterAndLoginTimeoutAreNoOps() throws SQLException {
+        ConnectionOptions options =
+                ConnectionOptions.builder().withUrl("jdbc:h2:mem:datasource_noops").build();
+        ConnectionDataSource dataSource = new ConnectionDataSource(options, () -> null);
+
+        assertThat(dataSource.getLogWriter()).isNull();
+        dataSource.setLogWriter(null);
+        dataSource.setLoginTimeout(30);
+        assertThat(dataSource.getLoginTimeout()).isZero();
+    }
+
+    @Test
+    void testGetParentLoggerThrowsUnsupported() {
+        ConnectionOptions options =
+                ConnectionOptions.builder().withUrl("jdbc:h2:mem:datasource_logger").build();
+        ConnectionDataSource dataSource = new ConnectionDataSource(options, () -> null);
+
+        assertThatThrownBy(dataSource::getParentLogger)
+                .isInstanceOf(SQLFeatureNotSupportedException.class);
+    }
+
+    @Test
+    void testUnwrapThrowsAndIsWrapperForIsFalse() {
+        ConnectionOptions options =
+                ConnectionOptions.builder().withUrl("jdbc:h2:mem:datasource_wrapper").build();
+        ConnectionDataSource dataSource = new ConnectionDataSource(options, () -> null);
+
+        assertThatThrownBy(() -> dataSource.unwrap(Driver.class)).isInstanceOf(SQLException.class);
+        assertThat(dataSource.isWrapperFor(Driver.class)).isFalse();
+    }
+}

--- a/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/datastream/connection/ConnectionExceptionTest.java
+++ b/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/datastream/connection/ConnectionExceptionTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.core.datastream.connection;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConnectionExceptionTest {
+
+    @Test
+    void testMessageOnlyConstructor() {
+        ConnectionException exception = new ConnectionException("failed");
+
+        assertThat(exception.getMessage()).isEqualTo("failed");
+        assertThat(exception.getCause()).isNull();
+        assertThat(exception).isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void testCauseOnlyConstructor() {
+        Exception cause = new SQLException("root cause");
+
+        ConnectionException exception = new ConnectionException(cause);
+
+        assertThat(exception.getCause()).isSameAs(cause);
+    }
+
+    @Test
+    void testMessageAndCauseConstructor() {
+        Exception cause = new SQLException("root cause");
+
+        ConnectionException exception = new ConnectionException("failed", cause);
+
+        assertThat(exception.getMessage()).isEqualTo("failed");
+        assertThat(exception.getCause()).isSameAs(cause);
+    }
+}

--- a/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/datastream/connection/ConnectionOptionsBuilderTest.java
+++ b/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/datastream/connection/ConnectionOptionsBuilderTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.core.datastream.connection;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ConnectionOptionsBuilderTest {
+
+    @Test
+    void testBuildWithAllFieldsSet() {
+        ConnectionOptions options =
+                ConnectionOptions.builder()
+                        .withUrl("jdbc:h2:mem:test")
+                        .withDriverName("org.h2.Driver")
+                        .withUsername("user")
+                        .withPassword("pass")
+                        .withConnectionCheckTimeout(Duration.ofSeconds(10))
+                        .withConnectionQueryTimeout(Duration.ofSeconds(20))
+                        .withProperty("customKey", "customValue")
+                        .build();
+
+        assertThat(options.getDbURL()).isEqualTo("jdbc:h2:mem:test");
+        assertThat(options.getDriverName()).isEqualTo("org.h2.Driver");
+        assertThat(options.getConnectionCheckTimeoutSeconds()).isEqualTo(10);
+        assertThat(options.getConnectionQueryTimeoutSeconds()).isEqualTo(20);
+        assertThat(options.getUsername()).contains("user");
+        assertThat(options.getPassword()).contains("pass");
+        assertThat(options.getProperties().getProperty("customKey")).isEqualTo("customValue");
+    }
+
+    @Test
+    void testDefaultTimeoutsAreSixtySeconds() {
+        ConnectionOptions options = ConnectionOptions.builder().withUrl("jdbc:h2:mem:test").build();
+
+        assertThat(options.getConnectionCheckTimeoutSeconds()).isEqualTo(60);
+        assertThat(options.getConnectionQueryTimeoutSeconds()).isEqualTo(60);
+    }
+
+    @Test
+    void testDriverNameIsOptional() {
+        ConnectionOptions options = ConnectionOptions.builder().withUrl("jdbc:h2:mem:test").build();
+
+        assertThat(options.getDriverName()).isNull();
+    }
+
+    @Test
+    void testNullUsernameAndPasswordAreNotAddedToProperties() {
+        ConnectionOptions options =
+                ConnectionOptions.builder()
+                        .withUrl("jdbc:h2:mem:test")
+                        .withUsername(null)
+                        .withPassword(null)
+                        .build();
+
+        assertThat(options.getUsername()).isEmpty();
+        assertThat(options.getPassword()).isEmpty();
+    }
+
+    @Test
+    void testWithPropertyRejectsNullKeyOrValue() {
+        ConnectionOptionsBuilder builder = ConnectionOptions.builder();
+
+        assertThatThrownBy(() -> builder.withProperty(null, "value"))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> builder.withProperty("key", null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testWithConnectionCheckTimeoutRejectsNull() {
+        ConnectionOptionsBuilder builder = ConnectionOptions.builder();
+
+        assertThatThrownBy(() -> builder.withConnectionCheckTimeout(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testWithConnectionQueryTimeoutRejectsNull() {
+        ConnectionOptionsBuilder builder = ConnectionOptions.builder();
+
+        assertThatThrownBy(() -> builder.withConnectionQueryTimeout(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+}

--- a/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/datastream/connection/NullConnectingDriver.java
+++ b/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/datastream/connection/NullConnectingDriver.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.core.datastream.connection;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+/**
+ * Test-only {@link Driver} whose {@link #connect} always returns {@code null}, simulating a driver
+ * that doesn't recognize the given URL. Used to deterministically exercise the "no suitable driver
+ * found" error path without depending on a real driver's URL-matching behavior.
+ */
+class NullConnectingDriver implements Driver {
+
+    @Override
+    public Connection connect(String url, Properties info) {
+        return null;
+    }
+
+    @Override
+    public boolean acceptsURL(String url) {
+        return false;
+    }
+
+    @Override
+    public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) {
+        return new DriverPropertyInfo[0];
+    }
+
+    @Override
+    public int getMajorVersion() {
+        return 1;
+    }
+
+    @Override
+    public int getMinorVersion() {
+        return 0;
+    }
+
+    @Override
+    public boolean jdbcCompliant() {
+        return false;
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        throw new SQLFeatureNotSupportedException();
+    }
+}

--- a/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/datastream/source/enumerator/splitter/snapshot/AsyncSnapshotSplitterEnumeratorTest.java
+++ b/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/datastream/source/enumerator/splitter/snapshot/AsyncSnapshotSplitterEnumeratorTest.java
@@ -1,0 +1,271 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot;
+
+import org.apache.flink.connector.jdbc.core.datastream.source.split.JdbcSourceSplit;
+import org.apache.flink.connector.jdbc.datasource.connections.JdbcConnectionProvider;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BooleanSupplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AsyncSnapshotSplitterEnumeratorTest {
+
+    @Test
+    void testOfferAndOfferAllArePickedUpByEnumerateSplits() {
+        TestAsyncEnumerator enumerator =
+                new TestAsyncEnumerator(
+                        self -> {
+                            self.offer("a");
+                            self.offerAll(Arrays.asList("b", "c"));
+                        });
+
+        enumerator.startBackgroundWork();
+        List<JdbcSourceSplit> splits = drainAllSplits(enumerator);
+
+        assertThat(splits.stream().map(JdbcSourceSplit::getSqlTemplate))
+                .containsExactlyInAnyOrder("a", "b", "c");
+        assertThat(enumerator.isAllSplitsFinished()).isTrue();
+    }
+
+    @Test
+    void testOfferAllWithEmptyCollectionDoesNotWakeUpEarly() {
+        TestAsyncEnumerator enumerator =
+                new TestAsyncEnumerator(
+                        self -> {
+                            self.offerAll(Collections.emptyList());
+                            self.offer("only");
+                        });
+
+        enumerator.startBackgroundWork();
+        List<JdbcSourceSplit> splits = drainAllSplits(enumerator);
+
+        assertThat(splits).hasSize(1);
+    }
+
+    @Test
+    void testIsAllSplitsFinishedFalseBeforeStart() {
+        TestAsyncEnumerator enumerator = new TestAsyncEnumerator(self -> {});
+
+        assertThat(enumerator.isAllSplitsFinished()).isFalse();
+    }
+
+    @Test
+    void testBackgroundFailurePropagatesAsIllegalStateException() {
+        RuntimeException failure = new RuntimeException("boom");
+        TestAsyncEnumerator enumerator =
+                new TestAsyncEnumerator(
+                        self -> {
+                            throw failure;
+                        });
+
+        enumerator.startBackgroundWork();
+
+        assertThatThrownBy(enumerator::enumerateSplits)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Split computation failed")
+                .cause()
+                .isSameAs(failure);
+        assertThat(enumerator.isAllSplitsFinished()).isTrue();
+    }
+
+    @Test
+    void testInterruptedExceptionDuringBackgroundWorkDoesNotSetFailure()
+            throws InterruptedException {
+        TestAsyncEnumerator enumerator =
+                new TestAsyncEnumerator(
+                        self -> {
+                            throw new InterruptedException("interrupted");
+                        });
+
+        enumerator.startBackgroundWork();
+        // Give the background thread a moment to run and hit the finally block.
+        waitUntil(enumerator::isAllSplitsFinished);
+
+        assertThat(enumerator.enumerateSplits()).isEmpty();
+        assertThat(enumerator.isAllSplitsFinished()).isTrue();
+        // Clear the interrupt flag set on this test thread's pool worker isn't relevant here;
+        // only the background thread's flag is set, which is a distinct thread.
+    }
+
+    @Test
+    void testCloseBeforeStartDoesNotThrowAndCallsCloseResources() {
+        TestAsyncEnumerator enumerator = new TestAsyncEnumerator(self -> {});
+
+        enumerator.close();
+
+        assertThat(enumerator.closeResourcesCalls.get()).isEqualTo(1);
+    }
+
+    @Test
+    void testCloseAfterStartShutsDownBackgroundThreadAndCallsCloseResources()
+            throws InterruptedException {
+        CountDownLatch blockUntilClosed = new CountDownLatch(1);
+        TestAsyncEnumerator enumerator =
+                new TestAsyncEnumerator(
+                        self -> {
+                            self.offer("first");
+                            blockUntilClosed.await();
+                        });
+
+        enumerator.startBackgroundWork();
+        // Wait for the first item so we know the background thread is actually running.
+        assertThat(enumerator.enumerateSplits()).hasSize(1);
+
+        enumerator.close();
+
+        assertThat(enumerator.closeResourcesCalls.get()).isEqualTo(1);
+    }
+
+    @Test
+    void testGetBoundednessIsContinuousUnbounded() {
+        TestAsyncEnumerator enumerator = new TestAsyncEnumerator(self -> {});
+
+        assertThat(enumerator.getBoundedness().name()).isEqualTo("CONTINUOUS_UNBOUNDED");
+    }
+
+    @Test
+    void testSerializableStateAndRestoreState() {
+        TestAsyncEnumerator enumerator = new TestAsyncEnumerator(self -> {});
+
+        assertThat(enumerator.serializableState()).isNull();
+        assertThat(enumerator.restoreState(null)).isSameAs(enumerator);
+    }
+
+    @Test
+    void testInitConnectionRejectsNonConnectionProviderInstance() {
+        TestAsyncEnumerator enumerator = new TestAsyncEnumerator(self -> {});
+
+        assertThatThrownBy(() -> enumerator.initConnection(new NotAConnectionProvider()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("ConnectionProvider");
+    }
+
+    @Test
+    void testInitConnectionAcceptsConnectionProviderInstance() {
+        TestAsyncEnumerator enumerator = new TestAsyncEnumerator(self -> {});
+        FakeConnectionProvider connectionProvider =
+                new FakeConnectionProvider(
+                        Collections.emptySet(), new HashMap<>(), new HashMap<>());
+
+        enumerator.initConnection(connectionProvider);
+
+        assertThat(enumerator.connection).isSameAs(connectionProvider);
+    }
+
+    private static void waitUntil(BooleanSupplier condition) throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (!condition.getAsBoolean() && System.nanoTime() < deadline) {
+            Thread.sleep(20);
+        }
+    }
+
+    private static List<JdbcSourceSplit> drainAllSplits(
+            AsyncSnapshotSplitterEnumerator<?> enumerator) {
+        List<JdbcSourceSplit> allSplits = new ArrayList<>();
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        do {
+            allSplits.addAll(enumerator.enumerateSplits());
+        } while (!enumerator.isAllSplitsFinished() && System.nanoTime() < deadline);
+        return allSplits;
+    }
+
+    /**
+     * Not a {@link org.apache.flink.connector.jdbc.core.datastream.connection.ConnectionProvider}.
+     */
+    private static final class NotAConnectionProvider implements JdbcConnectionProvider {
+        @Override
+        public Connection getConnection() {
+            return null;
+        }
+
+        @Override
+        public boolean isConnectionValid() {
+            return false;
+        }
+
+        @Override
+        public Connection getOrEstablishConnection() {
+            return null;
+        }
+
+        @Override
+        public void closeConnection() {}
+
+        @Override
+        public Connection reestablishConnection() {
+            return null;
+        }
+    }
+
+    /** Functional interface for the background work under test, given access to {@code this}. */
+    @FunctionalInterface
+    private interface BackgroundWork {
+        void run(TestAsyncEnumerator self) throws Exception;
+    }
+
+    /** Minimal concrete subclass exercising the shared async lifecycle machinery. */
+    private static final class TestAsyncEnumerator extends AsyncSnapshotSplitterEnumerator<String> {
+
+        private final BackgroundWork work;
+        final AtomicInteger closeResourcesCalls = new AtomicInteger();
+
+        TestAsyncEnumerator(BackgroundWork work) {
+            super("test");
+            this.work = work;
+        }
+
+        @Override
+        public void start(JdbcConnectionProvider connectionProvider) {
+            initConnection(connectionProvider);
+            startBackgroundWork();
+        }
+
+        @Override
+        public List<String> lineageQueries() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        protected void runBackgroundWork() throws Exception {
+            work.run(this);
+        }
+
+        @Override
+        protected JdbcSourceSplit toSplit(String item) {
+            return new JdbcSourceSplit(item, item, null, null);
+        }
+
+        @Override
+        protected void closeResources() {
+            closeResourcesCalls.incrementAndGet();
+        }
+    }
+}

--- a/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/datastream/source/enumerator/splitter/snapshot/DatabaseSplitterEnumeratorBuilderTest.java
+++ b/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/datastream/source/enumerator/splitter/snapshot/DatabaseSplitterEnumeratorBuilderTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DatabaseSplitterEnumeratorBuilderTest {
+
+    @Test
+    void testBuildWithValidParameters() {
+        DatabaseSplitterEnumerator enumerator =
+                DatabaseSplitterEnumerator.builder()
+                        .withCatalogName("catalog")
+                        .withSchemaName("schema")
+                        .withTableNames("orders", "customers")
+                        .withChunkSize(500)
+                        .build();
+
+        assertThat(enumerator).isNotNull();
+    }
+
+    @Test
+    void testChunkSizeMustBePositive() {
+        assertThatThrownBy(() -> DatabaseSplitterEnumerator.builder().withChunkSize(0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("chunkSize");
+
+        assertThatThrownBy(() -> DatabaseSplitterEnumerator.builder().withChunkSize(-1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("chunkSize");
+    }
+
+    @Test
+    void testDefaultChunkSizeIsApplied() {
+        DatabaseSplitterEnumerator enumerator =
+                DatabaseSplitterEnumerator.builder()
+                        .withCatalogName("catalog")
+                        .withSchemaName("schema")
+                        .build();
+
+        assertThat(enumerator).isNotNull();
+    }
+
+    @Test
+    void testWithTableNamesVarargsAndSetAreAdditive() {
+        DatabaseSplitterEnumerator enumerator =
+                DatabaseSplitterEnumerator.builder()
+                        .withCatalogName("catalog")
+                        .withSchemaName("schema")
+                        .withTableNames("orders")
+                        .withTableNames("customers", "products")
+                        .build();
+
+        assertThat(enumerator).isNotNull();
+    }
+}

--- a/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/datastream/source/enumerator/splitter/snapshot/DatabaseSplitterEnumeratorTest.java
+++ b/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/datastream/source/enumerator/splitter/snapshot/DatabaseSplitterEnumeratorTest.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot;
+
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.SplitterEnumerator;
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain.Table;
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain.TableColumn;
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain.TableId;
+import org.apache.flink.connector.jdbc.core.datastream.source.split.JdbcSourceSplit;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DatabaseSplitterEnumeratorTest {
+
+    private static final TableId ORDERS = new TableId("catalog", "schema", "orders");
+    private static final TableId CUSTOMERS = new TableId("catalog", "schema", "customers");
+
+    @Test
+    void testFanOutOverMultipleTables() {
+        // Single-row tables each collapse to exactly one split, isolating the fan-out behavior
+        // under test from the chunk-boundary counting already covered by
+        // TableSplitterEnumeratorTest.
+        FakeConnectionProvider connection =
+                fakeConnectionWithTables(
+                        tableEntry(ORDERS, values(1L)), tableEntry(CUSTOMERS, values(1L)));
+        DatabaseSplitterEnumerator enumerator = databaseSplitterFor("catalog", "schema");
+
+        enumerator.start(connection);
+        List<JdbcSourceSplit> splits = drainAllSplits(enumerator);
+
+        assertThat(splits).hasSize(2);
+        assertThat(enumerator.isAllSplitsFinished()).isTrue();
+    }
+
+    @Test
+    void testTableFilterExcludesNonMatchingTables() {
+        FakeConnectionProvider connection =
+                fakeConnectionWithTables(
+                        tableEntry(ORDERS, values(1L)), tableEntry(CUSTOMERS, values(1L)));
+        DatabaseSplitterEnumerator enumerator =
+                DatabaseSplitterEnumerator.builder()
+                        .withCatalogName("catalog")
+                        .withSchemaName("schema")
+                        .withTableNames("orders")
+                        .build();
+
+        enumerator.start(connection);
+        List<JdbcSourceSplit> splits = drainAllSplits(enumerator);
+
+        assertThat(splits).hasSize(1);
+        assertThat(splits.get(0).getSqlTemplate()).contains(ORDERS.toString());
+    }
+
+    @Test
+    void testTableFilterWithNoMatchThrows() {
+        FakeConnectionProvider connection =
+                fakeConnectionWithTables(tableEntry(ORDERS, values(1L)));
+        DatabaseSplitterEnumerator enumerator =
+                DatabaseSplitterEnumerator.builder()
+                        .withCatalogName("catalog")
+                        .withSchemaName("schema")
+                        .withTableNames("does_not_exist")
+                        .build();
+
+        assertThatThrownBy(() -> enumerator.start(connection))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("No tables found");
+    }
+
+    @Test
+    void testNoTablesInDatabaseThrows() {
+        FakeConnectionProvider connection =
+                new FakeConnectionProvider(
+                        Collections.emptySet(), new HashMap<>(), new HashMap<>());
+        DatabaseSplitterEnumerator enumerator = databaseSplitterFor("catalog", "schema");
+
+        assertThatThrownBy(() -> enumerator.start(connection))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("No tables found");
+    }
+
+    @Test
+    void testLineageQueriesAggregatesFromAllTableSplitters() {
+        FakeConnectionProvider connection =
+                fakeConnectionWithTables(
+                        tableEntry(ORDERS, values(1L)), tableEntry(CUSTOMERS, values(1L)));
+        DatabaseSplitterEnumerator enumerator = databaseSplitterFor("catalog", "schema");
+
+        enumerator.start(connection);
+        drainAllSplits(enumerator);
+
+        assertThat(enumerator.lineageQueries()).hasSize(2);
+    }
+
+    @Test
+    void testCloseClosesAllTableSplitterConnections() {
+        FakeConnectionProvider connection =
+                fakeConnectionWithTables(
+                        tableEntry(ORDERS, values(1L)), tableEntry(CUSTOMERS, values(1L)));
+        DatabaseSplitterEnumerator enumerator = databaseSplitterFor("catalog", "schema");
+
+        enumerator.start(connection);
+        drainAllSplits(enumerator);
+        enumerator.close();
+
+        // One closeConnection() call per table splitter (the parent's own connection is not
+        // closed).
+        assertThat(connection.closeCount).hasValue(2);
+    }
+
+    @Test
+    void testCloseBeforeStartDoesNotThrow() {
+        DatabaseSplitterEnumerator enumerator = databaseSplitterFor("catalog", "schema");
+
+        assertThat(enumerator.isAllSplitsFinished()).isFalse();
+        enumerator.close();
+    }
+
+    private static DatabaseSplitterEnumerator databaseSplitterFor(String catalog, String schema) {
+        return DatabaseSplitterEnumerator.builder()
+                .withCatalogName(catalog)
+                .withSchemaName(schema)
+                .build();
+    }
+
+    private static TableColumn idColumnPk() {
+        return TableColumn.builder()
+                .withColumnName("id")
+                .withColumnType("int8")
+                .withColumnPosition(1)
+                .withColumnNullable(false)
+                .withColumnPk(true)
+                .build();
+    }
+
+    private static LinkedHashSet<Long> values(Long... values) {
+        return new LinkedHashSet<>(Arrays.asList(values));
+    }
+
+    private static Map.Entry<TableId, LinkedHashSet<Long>> tableEntry(
+            TableId tableId, LinkedHashSet<Long> values) {
+        return new java.util.AbstractMap.SimpleEntry<>(tableId, values);
+    }
+
+    @SafeVarargs
+    private static FakeConnectionProvider fakeConnectionWithTables(
+            Map.Entry<TableId, LinkedHashSet<Long>>... tableEntries) {
+        Set<Table> tables = new HashSet<>();
+        Map<TableId, Set<TableColumn>> columnsByTable = new HashMap<>();
+        Map<TableId, LinkedHashSet<Long>> valuesByTable = new HashMap<>();
+        for (Map.Entry<TableId, LinkedHashSet<Long>> entry : tableEntries) {
+            tables.add(new Table(entry.getKey(), Collections.emptySet()));
+            columnsByTable.put(entry.getKey(), Collections.singleton(idColumnPk()));
+            valuesByTable.put(entry.getKey(), entry.getValue());
+        }
+        return new FakeConnectionProvider(tables, columnsByTable, valuesByTable);
+    }
+
+    private static List<JdbcSourceSplit> drainAllSplits(SplitterEnumerator enumerator) {
+        List<JdbcSourceSplit> allSplits = new ArrayList<>();
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        do {
+            allSplits.addAll(enumerator.enumerateSplits());
+        } while (!enumerator.isAllSplitsFinished() && System.nanoTime() < deadline);
+        return allSplits;
+    }
+}

--- a/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/datastream/source/enumerator/splitter/snapshot/FakeConnectionProvider.java
+++ b/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/datastream/source/enumerator/splitter/snapshot/FakeConnectionProvider.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot;
+
+import org.apache.flink.connector.jdbc.core.datastream.connection.ConnectionProvider;
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain.Table;
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain.TableBounds;
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain.TableColumn;
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain.TableId;
+
+import java.sql.Connection;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * In-memory {@link ConnectionProvider} test double. Simulates table/column metadata and primary key
+ * value ranges purely in memory — no real JDBC connection is ever involved.
+ */
+class FakeConnectionProvider implements ConnectionProvider {
+
+    private final Set<Table> tables;
+    private final Map<TableId, Set<TableColumn>> columnsByTable;
+    private final Map<TableId, LinkedHashSet<Long>> primaryKeyValuesByTable;
+
+    final AtomicInteger closeCount = new AtomicInteger();
+
+    FakeConnectionProvider(
+            Set<Table> tables,
+            Map<TableId, Set<TableColumn>> columnsByTable,
+            Map<TableId, LinkedHashSet<Long>> primaryKeyValuesByTable) {
+        this.tables = tables;
+        this.columnsByTable = columnsByTable;
+        this.primaryKeyValuesByTable = primaryKeyValuesByTable;
+    }
+
+    @Override
+    public Set<Table> getTables(String catalog, String schema) {
+        return tables;
+    }
+
+    @Override
+    public Set<TableColumn> getTableColumns(TableId tableId) {
+        return columnsByTable.get(tableId);
+    }
+
+    @Override
+    public String createQueryWithBounds(
+            TableId tableId, Set<String> tableColumns, TableColumn pkColumn, TableBounds bounds) {
+        return "SELECT * FROM " + tableId + " WHERE bounds=" + bounds;
+    }
+
+    @Override
+    public TableBounds queryMinMax(TableId tableId, TableColumn column) {
+        LinkedHashSet<Long> values = primaryKeyValuesByTable.get(tableId);
+        if (values == null || values.isEmpty()) {
+            return TableBounds.empty();
+        }
+        long first = values.iterator().next();
+        long last = first;
+        for (long v : values) {
+            last = v;
+        }
+        return TableBounds.of(first, last);
+    }
+
+    @Override
+    public Optional<Object> queryNextChunkMax(
+            TableId tableId, TableColumn column, Object lowerBound, long chunkSize) {
+        LinkedHashSet<Long> values = primaryKeyValuesByTable.get(tableId);
+        long lower = (Long) lowerBound;
+        long seen = 0;
+        for (long v : values) {
+            if (v > lower) {
+                seen++;
+                if (seen == chunkSize) {
+                    return Optional.of(v);
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public ConnectionProvider newInstance() {
+        return this;
+    }
+
+    @Override
+    public Connection getConnection() {
+        return null;
+    }
+
+    @Override
+    public boolean isConnectionValid() {
+        return true;
+    }
+
+    @Override
+    public Connection getOrEstablishConnection() {
+        return null;
+    }
+
+    @Override
+    public void closeConnection() {
+        closeCount.incrementAndGet();
+    }
+
+    @Override
+    public Connection reestablishConnection() {
+        return null;
+    }
+}

--- a/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/datastream/source/enumerator/splitter/snapshot/TableSplitterEnumeratorBuilderTest.java
+++ b/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/datastream/source/enumerator/splitter/snapshot/TableSplitterEnumeratorBuilderTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TableSplitterEnumeratorBuilderTest {
+
+    @Test
+    void testBuildWithValidParameters() {
+        TableSplitterEnumerator enumerator =
+                TableSplitterEnumerator.builder()
+                        .withCatalogName("catalog")
+                        .withSchemaName("schema")
+                        .withTableName("table")
+                        .withColumnNames("id", "name")
+                        .withChunkSize(500)
+                        .build();
+
+        assertThat(enumerator).isNotNull();
+    }
+
+    @Test
+    void testChunkSizeMustBePositive() {
+        assertThatThrownBy(() -> TableSplitterEnumerator.builder().withChunkSize(0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("chunkSize");
+
+        assertThatThrownBy(() -> TableSplitterEnumerator.builder().withChunkSize(-1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("chunkSize");
+    }
+
+    @Test
+    void testDefaultChunkSizeIsApplied() {
+        // Should not throw despite never calling withChunkSize — a default is used.
+        TableSplitterEnumerator enumerator =
+                TableSplitterEnumerator.builder()
+                        .withCatalogName("catalog")
+                        .withSchemaName("schema")
+                        .withTableName("table")
+                        .build();
+
+        assertThat(enumerator).isNotNull();
+    }
+
+    @Test
+    void testWithColumnNamesVarargsAndSetAreAdditive() {
+        TableSplitterEnumerator enumerator =
+                TableSplitterEnumerator.builder()
+                        .withCatalogName("catalog")
+                        .withSchemaName("schema")
+                        .withTableName("table")
+                        .withColumnNames("id")
+                        .withColumnNames("name", "email")
+                        .build();
+
+        assertThat(enumerator).isNotNull();
+    }
+}

--- a/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/datastream/source/enumerator/splitter/snapshot/TableSplitterEnumeratorTest.java
+++ b/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/datastream/source/enumerator/splitter/snapshot/TableSplitterEnumeratorTest.java
@@ -1,0 +1,297 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot;
+
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.SplitterEnumerator;
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain.TableColumn;
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain.TableId;
+import org.apache.flink.connector.jdbc.core.datastream.source.split.JdbcSourceSplit;
+import org.apache.flink.connector.jdbc.datasource.connections.JdbcConnectionProvider;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TableSplitterEnumeratorTest {
+
+    private static final TableId TABLE_ID = new TableId("catalog", "schema", "orders");
+
+    @Test
+    void testStartRejectsNonConnectionProviderInstance() {
+        TableSplitterEnumerator enumerator = tableSplitterFor(TABLE_ID);
+        JdbcConnectionProvider notAConnectionProvider = new NotAConnectionProvider();
+
+        assertThatThrownBy(() -> enumerator.start(notAConnectionProvider))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("ConnectionProvider");
+    }
+
+    @Test
+    void testEmptyTableProducesSingleEmptySplit() throws InterruptedException {
+        FakeConnectionProvider connection =
+                fakeConnection(TABLE_ID, idColumn(), new LinkedHashSet<>());
+        TableSplitterEnumerator enumerator = tableSplitterFor(TABLE_ID);
+
+        enumerator.start(connection);
+        List<JdbcSourceSplit> splits = drainAllSplits(enumerator);
+
+        assertThat(splits).hasSize(1);
+        assertThat(splits.get(0).getParameters()).isNull();
+        assertThat(enumerator.isAllSplitsFinished()).isTrue();
+    }
+
+    @Test
+    void testSingleRowTableProducesSingleSplit() throws InterruptedException {
+        FakeConnectionProvider connection = fakeConnection(TABLE_ID, idColumn(), values(5L));
+        TableSplitterEnumerator enumerator = tableSplitterFor(TABLE_ID);
+
+        enumerator.start(connection);
+        List<JdbcSourceSplit> splits = drainAllSplits(enumerator);
+
+        assertThat(splits).hasSize(1);
+        assertThat(splits.get(0).getParameters()).isNull();
+    }
+
+    @Test
+    void testMultiChunkTableProducesBoundedAndUnboundedSplits() throws InterruptedException {
+        LinkedHashSet<Long> pkValues = new LinkedHashSet<>();
+        for (long i = 1; i <= 25; i++) {
+            pkValues.add(i);
+        }
+        FakeConnectionProvider connection = fakeConnection(TABLE_ID, idColumn(), pkValues);
+        TableSplitterEnumerator enumerator =
+                TableSplitterEnumerator.builder()
+                        .withCatalogName(TABLE_ID.catalogName())
+                        .withSchemaName(TABLE_ID.schemaName())
+                        .withTableName(TABLE_ID.tableName())
+                        .withChunkSize(10)
+                        .build();
+
+        enumerator.start(connection);
+        List<JdbcSourceSplit> splits = drainAllSplits(enumerator);
+
+        // Bounds: (null,1), (1,11), (11,21), (21,25), (25,null)
+        assertThat(splits).hasSize(5);
+        assertThat(splits.get(0).getParameters()).containsExactly(1L);
+        assertThat(splits.get(1).getParameters()).containsExactly(1L, 11L);
+        assertThat(splits.get(2).getParameters()).containsExactly(11L, 21L);
+        assertThat(splits.get(3).getParameters()).containsExactly(21L, 25L);
+        assertThat(splits.get(4).getParameters()).containsExactly(25L);
+    }
+
+    @Test
+    void testMissingColumnNameThrows() throws InterruptedException {
+        FakeConnectionProvider connection = fakeConnection(TABLE_ID, idColumn(), values(1L, 2L));
+        TableSplitterEnumerator enumerator =
+                TableSplitterEnumerator.builder()
+                        .withCatalogName(TABLE_ID.catalogName())
+                        .withSchemaName(TABLE_ID.schemaName())
+                        .withTableName(TABLE_ID.tableName())
+                        .withColumnNames("does_not_exist")
+                        .build();
+
+        enumerator.start(connection);
+
+        assertThatThrownBy(() -> drainAllSplits(enumerator))
+                .isInstanceOf(IllegalStateException.class)
+                .hasCauseInstanceOf(IllegalArgumentException.class)
+                .cause()
+                .hasMessageContaining("does_not_exist");
+    }
+
+    @Test
+    void testNoPrimaryKeyThrows() throws InterruptedException {
+        TableColumn columnWithoutPk =
+                TableColumn.builder()
+                        .withColumnName("id")
+                        .withColumnType("int8")
+                        .withColumnPosition(1)
+                        .withColumnNullable(false)
+                        .withColumnPk(false)
+                        .build();
+        FakeConnectionProvider connection =
+                fakeConnection(TABLE_ID, Collections.singleton(columnWithoutPk), values(1L));
+        TableSplitterEnumerator enumerator = tableSplitterFor(TABLE_ID);
+
+        enumerator.start(connection);
+
+        assertThatThrownBy(() -> drainAllSplits(enumerator))
+                .isInstanceOf(IllegalStateException.class)
+                .hasCauseInstanceOf(IllegalArgumentException.class)
+                .cause()
+                .hasMessageContaining("does not have a primary key");
+    }
+
+    @Test
+    void testCompositePrimaryKeyUsesFirstFieldByPosition() throws InterruptedException {
+        TableColumn firstPk =
+                TableColumn.builder()
+                        .withColumnName("id")
+                        .withColumnType("int8")
+                        .withColumnPosition(1)
+                        .withColumnNullable(false)
+                        .withColumnPk(true)
+                        .build();
+        TableColumn secondPk =
+                TableColumn.builder()
+                        .withColumnName("id2")
+                        .withColumnType("int8")
+                        .withColumnPosition(2)
+                        .withColumnNullable(false)
+                        .withColumnPk(true)
+                        .build();
+        Set<TableColumn> columns = new LinkedHashSet<>(Arrays.asList(firstPk, secondPk));
+        FakeConnectionProvider connection = fakeConnection(TABLE_ID, columns, values(1L, 2L, 3L));
+        TableSplitterEnumerator enumerator = tableSplitterFor(TABLE_ID);
+
+        enumerator.start(connection);
+        List<JdbcSourceSplit> splits = drainAllSplits(enumerator);
+
+        // Doesn't throw, and chunks using the lower-positioned PK column ("id").
+        assertThat(splits).isNotEmpty();
+    }
+
+    @Test
+    void testLineageQueriesAggregatesGeneratedQueries() throws InterruptedException {
+        FakeConnectionProvider connection = fakeConnection(TABLE_ID, idColumn(), values(1L));
+        TableSplitterEnumerator enumerator = tableSplitterFor(TABLE_ID);
+
+        enumerator.start(connection);
+        List<JdbcSourceSplit> splits = drainAllSplits(enumerator);
+
+        assertThat(enumerator.lineageQueries()).hasSize(splits.size());
+        assertThat(enumerator.lineageQueries().get(0)).contains(TABLE_ID.toString());
+    }
+
+    @Test
+    void testCloseClosesConnection() {
+        FakeConnectionProvider connection = fakeConnection(TABLE_ID, idColumn(), values(1L));
+        TableSplitterEnumerator enumerator = tableSplitterFor(TABLE_ID);
+
+        enumerator.start(connection);
+        enumerator.close();
+
+        assertThat(connection.closeCount).hasValue(1);
+    }
+
+    @Test
+    void testCloseBeforeStartDoesNotThrow() {
+        TableSplitterEnumerator enumerator = tableSplitterFor(TABLE_ID);
+
+        assertThat(enumerator.isAllSplitsFinished()).isFalse();
+        enumerator.close();
+    }
+
+    @Test
+    void testGetBoundednessIsContinuousUnbounded() {
+        TableSplitterEnumerator enumerator = tableSplitterFor(TABLE_ID);
+
+        assertThat(enumerator.getBoundedness().name()).isEqualTo("CONTINUOUS_UNBOUNDED");
+    }
+
+    @Test
+    void testSerializableStateAndRestoreState() {
+        TableSplitterEnumerator enumerator = tableSplitterFor(TABLE_ID);
+
+        assertThat(enumerator.serializableState()).isNull();
+        assertThat(enumerator.restoreState(null)).isSameAs(enumerator);
+    }
+
+    private static TableSplitterEnumerator tableSplitterFor(TableId tableId) {
+        return TableSplitterEnumerator.builder()
+                .withCatalogName(tableId.catalogName())
+                .withSchemaName(tableId.schemaName())
+                .withTableName(tableId.tableName())
+                .build();
+    }
+
+    private static TableColumn idColumnPk() {
+        return TableColumn.builder()
+                .withColumnName("id")
+                .withColumnType("int8")
+                .withColumnPosition(1)
+                .withColumnNullable(false)
+                .withColumnPk(true)
+                .build();
+    }
+
+    private static Set<TableColumn> idColumn() {
+        return Collections.singleton(idColumnPk());
+    }
+
+    private static LinkedHashSet<Long> values(Long... values) {
+        return new LinkedHashSet<>(Arrays.asList(values));
+    }
+
+    private static FakeConnectionProvider fakeConnection(
+            TableId tableId, Set<TableColumn> columns, LinkedHashSet<Long> pkValues) {
+        Map<TableId, Set<TableColumn>> columnsByTable = new HashMap<>();
+        columnsByTable.put(tableId, columns);
+        Map<TableId, LinkedHashSet<Long>> valuesByTable = new HashMap<>();
+        valuesByTable.put(tableId, pkValues);
+        return new FakeConnectionProvider(Collections.emptySet(), columnsByTable, valuesByTable);
+    }
+
+    private static List<JdbcSourceSplit> drainAllSplits(SplitterEnumerator enumerator) {
+        List<JdbcSourceSplit> allSplits = new ArrayList<>();
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        do {
+            allSplits.addAll(enumerator.enumerateSplits());
+        } while (!enumerator.isAllSplitsFinished() && System.nanoTime() < deadline);
+        return allSplits;
+    }
+
+    /**
+     * Not a {@link org.apache.flink.connector.jdbc.core.datastream.connection.ConnectionProvider}.
+     */
+    private static final class NotAConnectionProvider implements JdbcConnectionProvider {
+        @Override
+        public java.sql.Connection getConnection() {
+            return null;
+        }
+
+        @Override
+        public boolean isConnectionValid() {
+            return false;
+        }
+
+        @Override
+        public java.sql.Connection getOrEstablishConnection() {
+            return null;
+        }
+
+        @Override
+        public void closeConnection() {}
+
+        @Override
+        public java.sql.Connection reestablishConnection() {
+            return null;
+        }
+    }
+}

--- a/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/datastream/source/enumerator/splitter/snapshot/domain/TableBoundsTest.java
+++ b/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/datastream/source/enumerator/splitter/snapshot/domain/TableBoundsTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.Serializable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TableBoundsTest {
+
+    @Test
+    void testOfIsNotEmpty() {
+        TableBounds bounds = TableBounds.of(1L, 10L);
+
+        assertThat(bounds.isEmpty()).isFalse();
+        assertThat(bounds.lowerBound()).isEqualTo(1L);
+        assertThat(bounds.upperBound()).isEqualTo(10L);
+    }
+
+    @Test
+    void testEmpty() {
+        TableBounds bounds = TableBounds.empty();
+
+        assertThat(bounds.isEmpty()).isTrue();
+        assertThat(bounds.lowerBound()).isNull();
+        assertThat(bounds.upperBound()).isNull();
+    }
+
+    @Test
+    void testGetBoundsAsParamsForEmptyIsNull() {
+        assertThat(TableBounds.empty().getBoundsAsParams()).isNull();
+    }
+
+    @Test
+    void testGetBoundsAsParamsWithBothBounds() {
+        Serializable[] params = TableBounds.of(1L, 10L).getBoundsAsParams();
+
+        assertThat(params).containsExactly(1L, 10L);
+    }
+
+    @Test
+    void testGetBoundsAsParamsWithOnlyLowerBound() {
+        Serializable[] params = TableBounds.of(10L, null).getBoundsAsParams();
+
+        assertThat(params).containsExactly(10L);
+    }
+
+    @Test
+    void testGetBoundsAsParamsWithOnlyUpperBound() {
+        Serializable[] params = TableBounds.of(null, 10L).getBoundsAsParams();
+
+        assertThat(params).containsExactly(10L);
+    }
+
+    @Test
+    void testEqualsAndHashCode() {
+        TableBounds a = TableBounds.of(1L, 10L);
+        TableBounds b = TableBounds.of(1L, 10L);
+        TableBounds different = TableBounds.of(1L, 20L);
+
+        assertThat(a).isEqualTo(b).hasSameHashCodeAs(b);
+        assertThat(a).isNotEqualTo(different);
+        assertThat(a).isNotEqualTo(null);
+        assertThat(a).isNotEqualTo("not a TableBounds");
+    }
+
+    @Test
+    void testToStringForEmpty() {
+        assertThat(TableBounds.empty()).hasToString("[]");
+    }
+
+    @Test
+    void testToStringWithBothBounds() {
+        assertThat(TableBounds.of(1L, 10L)).hasToString("[1,10]");
+    }
+
+    @Test
+    void testToStringWithOnlyLowerBound() {
+        assertThat(TableBounds.of(1L, null)).hasToString("[1,]");
+    }
+
+    @Test
+    void testToStringWithOnlyUpperBound() {
+        assertThat(TableBounds.of(null, 10L)).hasToString("[,10]");
+    }
+}

--- a/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/datastream/source/enumerator/splitter/snapshot/domain/TableColumnTest.java
+++ b/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/datastream/source/enumerator/splitter/snapshot/domain/TableColumnTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TableColumnTest {
+
+    @Test
+    void testBuilderAndAccessors() {
+        TableColumn column =
+                TableColumn.builder()
+                        .withColumnName("id")
+                        .withColumnType("int8")
+                        .withColumnPosition(1)
+                        .withColumnNullable(false)
+                        .withColumnPk(true)
+                        .build();
+
+        assertThat(column.columnName()).isEqualTo("id");
+        assertThat(column.columnType()).isEqualTo("int8");
+        assertThat(column.columnPosition()).isEqualTo(1);
+        assertThat(column.columnNullable()).isFalse();
+        assertThat(column.columnPrimaryKey()).isTrue();
+    }
+
+    @Test
+    void testIsUuidColumnTypeIsCaseInsensitive() {
+        assertThat(columnOfType("uuid").isUuidColumnType()).isTrue();
+        assertThat(columnOfType("UUID").isUuidColumnType()).isTrue();
+        assertThat(columnOfType("varchar").isUuidColumnType()).isFalse();
+    }
+
+    @Test
+    void testEqualsAndHashCode() {
+        TableColumn a = columnOfType("int8");
+        TableColumn b = columnOfType("int8");
+        TableColumn different = columnOfType("varchar");
+
+        assertThat(a).isEqualTo(b).hasSameHashCodeAs(b);
+        assertThat(a).isNotEqualTo(different);
+        assertThat(a).isNotEqualTo(null);
+        assertThat(a).isNotEqualTo("not a TableColumn");
+    }
+
+    @Test
+    void testToStringContainsFieldValues() {
+        TableColumn column = columnOfType("int8");
+
+        assertThat(column.toString()).contains("int8").contains("id");
+    }
+
+    private static TableColumn columnOfType(String columnType) {
+        return TableColumn.builder()
+                .withColumnName("id")
+                .withColumnType(columnType)
+                .withColumnPosition(1)
+                .withColumnNullable(false)
+                .withColumnPk(true)
+                .build();
+    }
+}

--- a/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/datastream/source/enumerator/splitter/snapshot/domain/TableIdTest.java
+++ b/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/datastream/source/enumerator/splitter/snapshot/domain/TableIdTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TableIdTest {
+
+    @Test
+    void testConstructorRejectsNulls() {
+        assertThatThrownBy(() -> new TableId(null, "schema", "table"))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new TableId("catalog", null, "table"))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new TableId("catalog", "schema", null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testAccessors() {
+        TableId tableId = new TableId("catalog", "schema", "table");
+
+        assertThat(tableId.catalogName()).isEqualTo("catalog");
+        assertThat(tableId.schemaName()).isEqualTo("schema");
+        assertThat(tableId.tableName()).isEqualTo("table");
+    }
+
+    @Test
+    void testToString() {
+        TableId tableId = new TableId("catalog", "schema", "table");
+
+        assertThat(tableId).hasToString("catalog.schema.table");
+    }
+
+    @Test
+    void testBuilder() {
+        TableId tableId =
+                TableId.builder()
+                        .withCatalogName("catalog")
+                        .withSchemaName("schema")
+                        .withTableName("table")
+                        .build();
+
+        assertThat(tableId).isEqualTo(new TableId("catalog", "schema", "table"));
+    }
+
+    @Test
+    void testEqualsAndHashCode() {
+        TableId a = new TableId("catalog", "schema", "table");
+        TableId b = new TableId("catalog", "schema", "table");
+        TableId different = new TableId("catalog", "schema", "other");
+
+        assertThat(a).isEqualTo(b).hasSameHashCodeAs(b);
+        assertThat(a).isNotEqualTo(different);
+        assertThat(a).isNotEqualTo(null);
+        assertThat(a).isNotEqualTo("not a TableId");
+        assertThat(a).isEqualTo(a);
+    }
+}

--- a/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/datastream/source/enumerator/splitter/snapshot/domain/TableTest.java
+++ b/flink-connector-jdbc-core/src/test/java/org/apache/flink/connector/jdbc/core/datastream/source/enumerator/splitter/snapshot/domain/TableTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TableTest {
+
+    private static final TableId TABLE_ID = new TableId("catalog", "schema", "table");
+
+    @Test
+    void testAccessors() {
+        Table table = new Table(TABLE_ID, setOf("p1", "p2"));
+
+        assertThat(table.tableId()).isEqualTo(TABLE_ID);
+        assertThat(table.partitions()).containsExactlyInAnyOrder("p1", "p2");
+    }
+
+    @Test
+    void testEqualsAndHashCode() {
+        Table a = new Table(TABLE_ID, Collections.singleton("p1"));
+        Table b = new Table(TABLE_ID, Collections.singleton("p1"));
+        Table differentPartitions = new Table(TABLE_ID, Collections.singleton("p2"));
+        Table differentTableId =
+                new Table(new TableId("catalog", "schema", "other"), Collections.singleton("p1"));
+
+        assertThat(a).isEqualTo(b).hasSameHashCodeAs(b);
+        assertThat(a).isNotEqualTo(differentPartitions);
+        assertThat(a).isNotEqualTo(differentTableId);
+        assertThat(a).isNotEqualTo(null);
+        assertThat(a).isNotEqualTo("not a Table");
+    }
+
+    @Test
+    void testToStringContainsTableIdAndPartitions() {
+        Table table = new Table(TABLE_ID, Collections.singleton("p1"));
+
+        assertThat(table.toString()).contains("catalog.schema.table").contains("p1");
+    }
+
+    private static Set<String> setOf(String... values) {
+        return new LinkedHashSet<>(Arrays.asList(values));
+    }
+}

--- a/flink-connector-jdbc-postgres/pom.xml
+++ b/flink-connector-jdbc-postgres/pom.xml
@@ -97,6 +97,18 @@ under the License.
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>7.0.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
         <!-- Assertions test dependencies -->
 
         <dependency>

--- a/flink-connector-jdbc-postgres/pom.xml
+++ b/flink-connector-jdbc-postgres/pom.xml
@@ -79,6 +79,18 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>7.0.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
         <!-- Assertions test dependencies -->
 
         <dependency>

--- a/flink-connector-jdbc-postgres/src/main/java/org/apache/flink/connector/jdbc/postgres/datastream/PostgresJdbc.java
+++ b/flink-connector-jdbc-postgres/src/main/java/org/apache/flink/connector/jdbc/postgres/datastream/PostgresJdbc.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.postgres.datastream;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.connector.jdbc.postgres.datastream.connection.PostgresConnectionOptions;
+
+/** Facade to create Postgres JDBC stream sources and sinks. */
+@PublicEvolving
+public class PostgresJdbc {
+
+    private final PostgresConnectionOptions connectionOptions;
+
+    private PostgresJdbc(PostgresConnectionOptions connectionOptions) {
+        this.connectionOptions = connectionOptions;
+    }
+
+    public static PostgresJdbc of(PostgresConnectionOptions connectionOptions) {
+        return new PostgresJdbc(connectionOptions);
+    }
+
+    public PostgresJdbcConsumer asConsumer() {
+        return PostgresJdbcConsumer.of(connectionOptions);
+    }
+}

--- a/flink-connector-jdbc-postgres/src/main/java/org/apache/flink/connector/jdbc/postgres/datastream/PostgresJdbcConsumer.java
+++ b/flink-connector-jdbc-postgres/src/main/java/org/apache/flink/connector/jdbc/postgres/datastream/PostgresJdbcConsumer.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.postgres.datastream;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.connector.jdbc.core.datastream.source.JdbcSource;
+import org.apache.flink.connector.jdbc.core.datastream.source.JdbcSourceBuilder;
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.SplitterEnumerator;
+import org.apache.flink.connector.jdbc.core.datastream.source.reader.extractor.ResultExtractor;
+import org.apache.flink.connector.jdbc.postgres.datastream.connection.PostgresConnectionOptions;
+import org.apache.flink.connector.jdbc.postgres.datastream.connection.PostgresConnectionProvider;
+
+/** Facade to create Postgres JDBC stream sources. */
+@PublicEvolving
+public class PostgresJdbcConsumer {
+
+    private final PostgresConnectionProvider connectionProvider;
+
+    private SplitterEnumerator splitterEnumerator;
+    private Integer resultFetchSize;
+    private Boolean autoCommit;
+
+    private PostgresJdbcConsumer(PostgresConnectionProvider connectionProvider) {
+        this.connectionProvider = connectionProvider;
+    }
+
+    public static PostgresJdbcConsumer of(PostgresConnectionOptions connectionOptions) {
+        return new PostgresJdbcConsumer(new PostgresConnectionProvider(connectionOptions.build()));
+    }
+
+    public PostgresJdbcConsumer withSplitterEnumerator(SplitterEnumerator splitterEnumerator) {
+        this.splitterEnumerator = splitterEnumerator;
+        return this;
+    }
+
+    public PostgresJdbcConsumer withResultFetchSize(int fetchSize) {
+        this.resultFetchSize = fetchSize;
+        return this;
+    }
+
+    public PostgresJdbcConsumer withAutoCommit(boolean autoCommit) {
+        this.autoCommit = autoCommit;
+        return this;
+    }
+
+    public <OUT> JdbcSource<OUT> build(JdbcExtractor<OUT> jdbcExtractor) {
+        JdbcSourceBuilder<OUT> builder =
+                JdbcSource.<OUT>builder()
+                        .setConnectionProvider(connectionProvider)
+                        .setSplitter(splitterEnumerator)
+                        .setResultExtractor(jdbcExtractor)
+                        .setTypeInformation(jdbcExtractor.typeInformation());
+
+        if (resultFetchSize != null && resultFetchSize > 0) {
+            builder.setResultSetFetchSize(resultFetchSize);
+        }
+
+        if (autoCommit != null) {
+            builder.setAutoCommit(autoCommit);
+        }
+
+        return builder.build();
+    }
+
+    /**
+     * A {@link ResultExtractor} that also knows the {@link TypeInformation} of what it extracts.
+     */
+    public interface JdbcExtractor<OUT> extends ResultExtractor<OUT> {
+        TypeInformation<OUT> typeInformation();
+    }
+}

--- a/flink-connector-jdbc-postgres/src/main/java/org/apache/flink/connector/jdbc/postgres/datastream/connection/PostgresConnectionOptions.java
+++ b/flink-connector-jdbc-postgres/src/main/java/org/apache/flink/connector/jdbc/postgres/datastream/connection/PostgresConnectionOptions.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.postgres.datastream.connection;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.connector.jdbc.core.datastream.connection.ConnectionOptions;
+import org.apache.flink.connector.jdbc.core.datastream.connection.ConnectionOptionsBuilder;
+
+import java.time.Duration;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Builder for creating Postgres-flavored {@link ConnectionOptions}. */
+@PublicEvolving
+public class PostgresConnectionOptions {
+
+    private String host;
+    private int port;
+    private String database;
+    private final ConnectionOptionsBuilder connectionOptions;
+
+    public PostgresConnectionOptions() {
+        this.connectionOptions = ConnectionOptions.builder();
+        this.connectionOptions.withDriverName("org.postgresql.Driver");
+    }
+
+    public static PostgresConnectionOptions create() {
+        return new PostgresConnectionOptions();
+    }
+
+    public PostgresConnectionOptions withHost(String host) {
+        this.host = host;
+        return this;
+    }
+
+    public PostgresConnectionOptions withPort(int port) {
+        this.port = port;
+        return this;
+    }
+
+    public PostgresConnectionOptions withDatabase(String database) {
+        this.database = database;
+        return this;
+    }
+
+    public PostgresConnectionOptions withDriverName(String driverName) {
+        this.connectionOptions.withDriverName(driverName);
+        return this;
+    }
+
+    public PostgresConnectionOptions withProperty(String propKey, String propVal) {
+        this.connectionOptions.withProperty(propKey, propVal);
+        return this;
+    }
+
+    public PostgresConnectionOptions withUsername(String username) {
+        this.connectionOptions.withUsername(username);
+        return this;
+    }
+
+    public PostgresConnectionOptions withPassword(String password) {
+        this.connectionOptions.withPassword(password);
+        return this;
+    }
+
+    public PostgresConnectionOptions withConnectionCheckTimeout(Duration connectionCheckTimeout) {
+        this.connectionOptions.withConnectionCheckTimeout(connectionCheckTimeout);
+        return this;
+    }
+
+    public PostgresConnectionOptions withConnectionQueryTimeout(Duration connectionQueryTimeout) {
+        this.connectionOptions.withConnectionQueryTimeout(connectionQueryTimeout);
+        return this;
+    }
+
+    public ConnectionOptions build() {
+        checkNotNull(host, "Connection host mustn't be null");
+        checkNotNull(port, "Connection port mustn't be null");
+        checkNotNull(database, "Connection database mustn't be null");
+        return connectionOptions
+                .withUrl(String.format("jdbc:postgresql://%s:%s/%s", host, port, database))
+                .build();
+    }
+}

--- a/flink-connector-jdbc-postgres/src/main/java/org/apache/flink/connector/jdbc/postgres/datastream/connection/PostgresConnectionProvider.java
+++ b/flink-connector-jdbc-postgres/src/main/java/org/apache/flink/connector/jdbc/postgres/datastream/connection/PostgresConnectionProvider.java
@@ -1,0 +1,307 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.postgres.datastream.connection;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.connector.jdbc.core.datastream.connection.AbstractConnectionProvider;
+import org.apache.flink.connector.jdbc.core.datastream.connection.ConnectionException;
+import org.apache.flink.connector.jdbc.core.datastream.connection.ConnectionOptions;
+import org.apache.flink.connector.jdbc.core.datastream.connection.ConnectionProvider;
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain.Table;
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain.TableBounds;
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain.TableColumn;
+import org.apache.flink.connector.jdbc.core.datastream.source.enumerator.splitter.snapshot.domain.TableId;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Postgres {@link ConnectionProvider} implementation backed by a pooled JDBC connection. Only the
+ * Postgres-specific table/partition discovery and bound-query building live here; the connection
+ * lifecycle, pooling, and statement plumbing are inherited from {@link AbstractConnectionProvider}.
+ */
+@PublicEvolving
+public class PostgresConnectionProvider extends AbstractConnectionProvider {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PostgresConnectionProvider.class);
+
+    private static final String TABLE_PARTITIONED_TYPE = "PARTITIONED TABLE";
+    private static final Set<String> TABLE_TYPES =
+            new HashSet<>(Arrays.asList("TABLE", TABLE_PARTITIONED_TYPE));
+    private static final Set<String> VIEW_TYPES =
+            new HashSet<>(Arrays.asList("VIEW", "MATERIALIZED VIEW"));
+    private static final String[] SUPPORTED_TYPES =
+            Stream.concat(TABLE_TYPES.stream(), VIEW_TYPES.stream()).toArray(String[]::new);
+
+    private static final int POOL_SIZE = 4;
+
+    private String snapshotId;
+    private String snapshotTxId;
+
+    public PostgresConnectionProvider(ConnectionOptions jdbcOptions) {
+        super(jdbcOptions);
+    }
+
+    private PostgresConnectionProvider(ConnectionOptions jdbcOptions, HikariDataSource pool) {
+        super(jdbcOptions, pool);
+    }
+
+    @Override
+    public ConnectionProvider newInstance() {
+        return new PostgresConnectionProvider(jdbcOptions, getOrCreatePool());
+    }
+
+    @Override
+    protected int maxPoolSize() {
+        return POOL_SIZE;
+    }
+
+    @Override
+    protected String poolName() {
+        return "postgres-splitter-pool";
+    }
+
+    @Override
+    protected void onConnectionEstablished() {
+        checkTransactionSnapshotTxId();
+    }
+
+    public void createGlobalSnapshotId() throws SQLException, ClassNotFoundException {
+        Connection currentConn = getOrEstablishConnection();
+        currentConn.setAutoCommit(false);
+        currentConn.setTransactionIsolation(Connection.TRANSACTION_REPEATABLE_READ);
+        try (Statement statement = currentConn.createStatement();
+                ResultSet resultSet = statement.executeQuery("SELECT pg_export_snapshot()")) {
+            if (resultSet.next()) {
+                snapshotId = resultSet.getString(1);
+                LOG.info("Created global snapshot id: {}", snapshotId);
+            }
+            snapshotTxId = currentSnapshotTxId();
+        }
+    }
+
+    private void checkTransactionSnapshotTxId() {
+        try {
+            if (snapshotId != null
+                    && isConnectionValid()
+                    && !snapshotTxId.equalsIgnoreCase(currentSnapshotTxId())) {
+                Connection currentConn = getConnection();
+                assert currentConn != null;
+                if (!currentConn.getAutoCommit()) {
+                    currentConn.rollback();
+                }
+                currentConn.setAutoCommit(false);
+                currentConn.setTransactionIsolation(Connection.TRANSACTION_REPEATABLE_READ);
+                LOG.info("Setting connection with snapshot id: {}", snapshotId);
+                try (PreparedStatement statement =
+                        currentConn.prepareStatement("SET TRANSACTION SNAPSHOT ?")) {
+                    statement.setString(1, snapshotId);
+                    statement.executeQuery();
+                }
+            }
+        } catch (SQLException e) {
+            throw new ConnectionException("Failed to set current snapshot txId to connection", e);
+        }
+    }
+
+    public String currentSnapshotTxId() throws SQLException {
+        Connection currentConn = getConnection();
+        if (currentConn == null) {
+            throw new SQLException("Connection is not established");
+        }
+        try (Statement statement = currentConn.createStatement();
+                ResultSet resultSet =
+                        statement.executeQuery("SELECT pg_current_snapshot()::text")) {
+            if (resultSet.next()) {
+                String txId = resultSet.getString(1);
+                LOG.info("Current global snapshot txId: {}", txId);
+                return txId;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public Set<Table> getTables(String catalog, String schema) {
+        return getTables(catalog, schema, TABLE_TYPES);
+    }
+
+    public Set<Table> getTables(String catalog, String schema, Set<String> supportedTypes) {
+        Map<TableId, Set<String>> tables = new HashMap<>();
+        try {
+            Connection conn = getOrEstablishConnection();
+            try (PreparedStatement parentPS =
+                            conn.prepareStatement("SELECT pg_partition_root(to_regclass(?))");
+                    ResultSet rs =
+                            conn.getMetaData()
+                                    .getTables(
+                                            catalog,
+                                            schema,
+                                            null,
+                                            supportedTypes.toArray(new String[0]))) {
+                while (rs.next()) {
+                    Optional<String> parent = Optional.empty();
+                    String tableType = rs.getString(4);
+                    String tableName = rs.getString(3);
+
+                    parent = getParent(parentPS, tableName);
+
+                    TableId tableId =
+                            TableId.builder()
+                                    .withCatalogName(
+                                            Optional.ofNullable(rs.getString(1)).orElse(catalog))
+                                    .withSchemaName(
+                                            Optional.ofNullable(rs.getString(2)).orElse(schema))
+                                    .withTableName(parent.orElse(tableName))
+                                    .build();
+
+                    Set<String> partitions = tables.getOrDefault(tableId, new HashSet<>());
+                    if (parent.isPresent() && !parent.get().equals(tableName)) {
+                        partitions.add(tableName);
+                    }
+                    tables.put(tableId, partitions);
+                }
+            }
+        } catch (SQLException | ClassNotFoundException e) {
+            throw new ConnectionException(
+                    "Failed to get tables for catalog " + catalog + " and schema " + schema, e);
+        }
+        return tables.entrySet().stream()
+                .map(kv -> new Table(kv.getKey(), kv.getValue()))
+                .collect(Collectors.toSet());
+    }
+
+    private Optional<String> getParent(PreparedStatement parentPS, String partitionName)
+            throws SQLException {
+        parentPS.setString(1, partitionName);
+        try (ResultSet rs = parentPS.executeQuery()) {
+            if (rs.next()) {
+                String parentTable = rs.getString(1);
+                return Optional.ofNullable(parentTable);
+            } else {
+                return Optional.empty();
+            }
+        }
+    }
+
+    @Override
+    public TableBounds queryMinMax(TableId tableId, TableColumn column) {
+        String columnName = quote(column.columnName());
+        if (column.isUuidColumnType()) {
+            columnName = castToText(columnName);
+        }
+        String query =
+                String.format(
+                        "SELECT MIN(%s), MAX(%s) FROM %s.%s",
+                        columnName, columnName, tableId.schemaName(), tableId.tableName());
+        return queryAndMap(
+                query,
+                rs -> {
+                    if (rs.next()) {
+                        return TableBounds.of(rs.getObject(1), rs.getObject(2));
+                    } else {
+                        return TableBounds.empty();
+                    }
+                });
+    }
+
+    @Override
+    public Optional<Object> queryNextChunkMax(
+            TableId tableId, TableColumn column, Object lowerBound, long chunkSize) {
+        String columnName = quote(column.columnName());
+        String query =
+                String.format(
+                        "SELECT %s FROM %s.%s WHERE %s > %s ORDER BY %s ASC OFFSET %d LIMIT 1",
+                        columnName,
+                        tableId.schemaName(),
+                        tableId.tableName(),
+                        columnName,
+                        (column.isUuidColumnType() ? castToUuid("?") : "?"),
+                        columnName,
+                        chunkSize - 1);
+        return this.prepareQueryAndMap(
+                query,
+                ps -> ps.setObject(1, lowerBound),
+                rs -> {
+                    if (rs.next()) {
+                        return Optional.ofNullable(rs.getObject(1));
+                    } else {
+                        return Optional.empty();
+                    }
+                });
+    }
+
+    @Override
+    public String createQueryWithBounds(
+            TableId tableId, Set<String> tableColumns, TableColumn pkColumn, TableBounds bounds) {
+        String query =
+                String.format(
+                        "SELECT %s FROM %s.%s",
+                        tableColumns.stream()
+                                .map(PostgresConnectionProvider::quote)
+                                .collect(Collectors.joining(",")),
+                        quote(tableId.schemaName()),
+                        quote(tableId.tableName()));
+        if (bounds.isEmpty()) {
+            return query;
+        }
+        query += " WHERE 1=1";
+        if (bounds.lowerBound() != null) {
+            query +=
+                    String.format(
+                            " AND %s >= %s",
+                            quote(pkColumn.columnName()),
+                            (pkColumn.isUuidColumnType() ? castToUuid("?") : "?"));
+        }
+        if (bounds.upperBound() != null) {
+            query +=
+                    String.format(
+                            " AND %s < %s",
+                            quote(pkColumn.columnName()),
+                            (pkColumn.isUuidColumnType() ? castToUuid("?") : "?"));
+        }
+        return query;
+    }
+
+    private static String quote(String name) {
+        return "\"" + name.replace("\"", "\"\"") + "\"";
+    }
+
+    private static String castToText(String value) {
+        return String.format("(%s)::text", value);
+    }
+
+    private static String castToUuid(String value) {
+        return String.format("(%s)::uuid", value);
+    }
+}


### PR DESCRIPTION
This pull request introduces a new connection management layer for the Flink JDBC connector, adding support for pluggable connection providers and improved connection configuration. The changes include new classes for connection options, a builder for those options, a minimal `DataSource` implementation for integration with connection pools, and interfaces for connection and statement handling. Additionally, HikariCP is added as a dependency (with SLF4J excluded), and a new async enumerator is provided for snapshot splitting.

**Connection Management and Configuration:**

* Added `ConnectionOptions` and `ConnectionOptionsBuilder` classes to encapsulate and build JDBC connection configuration, including timeouts and properties. [[1]](diffhunk://#diff-f001332fa66e39c36c0cc30834dda90a0fa41810bd7cd8bae6530ee856fede0fR1-R52) [[2]](diffhunk://#diff-b839c5096307f402ada2ccd9a7a55bcae8d79a27238b19ede6116d971769ee72R1-R91)
* Introduced `ConnectionDataSource`, a minimal `DataSource` implementation that delegates driver resolution, enabling proper classloader handling with connection pools like HikariCP.
* Added `ConnectionException` for consistent error handling around connection issues.
* Added `ConnectionProvider` interface, extending the base JDBC connection provider with methods for table/column metadata discovery and query building for snapshot splitters.

**Statement and Result Handling:**

* Introduced `ResultSetMapper` and `StatementPreparer` functional interfaces for mapping JDBC results and preparing statements, respectively. [[1]](diffhunk://#diff-eefcfd1c56b12cd6ab7d02efcdbd1ae004f7b609f6a820b95aafd8ea2c05d514R1-R33) [[2]](diffhunk://#diff-8507c8062c472a991cb94c4588edcac8fc52f3727db77c494dfb2cc586fcfb5bR1-R29)

**Async Snapshot Splitting:**

* Added `AsyncSnapshotSplitterEnumerator`, a background-threaded enumerator for computing and emitting snapshot splits asynchronously, improving scalability and responsiveness during snapshotting.

**Dependency Management:**

* Added HikariCP as a dependency in `pom.xml`, with SLF4J excluded to avoid conflicts.