### PR TITLE
[hotfix] Remove unused JUnit 4 dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,6 @@ under the License.
         <scala.binary.version>2.12</scala.binary.version>
         <scala-library.version>2.12.7</scala-library.version>
         <jackson-bom.version>2.13.4.20221013</jackson-bom.version>
-        <junit4.version>4.13.2</junit4.version>
         <junit5.version>5.10.1</junit5.version>
         <assertj.version>3.24.2</assertj.version>
         <testcontainers.version>1.20.1</testcontainers.version>
@@ -114,12 +113,6 @@ under the License.
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -282,12 +275,6 @@ under the License.
                 <version>${junit5.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>${junit4.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## What is the purpose of the change

The root `pom.xml` still declares JUnit 4 leftovers from the JUnit 5 migration: the `junit4.version` property, the `org.junit.vintage:junit-vintage-engine` test dependency, and the `junit:junit` entry in `<dependencyManagement>`. No test code in the repo uses JUnit 4 APIs (`org.junit.Test`, `@Before`, `@After`, `@Rule`) — every test class already runs on JUnit 5 (Jupiter). This PR removes the now-unused dependencies and property.

## Brief change log

- Remove the `junit4.version` property from `pom.xml`.
- Remove the `org.junit.vintage:junit-vintage-engine` test dependency from `pom.xml`.
- Remove the `junit:junit` dependency management entry from `pom.xml`.

## Verifying this change

This change is a pure dependency cleanup with no production or test code touched.

- Confirmed no `.java` file in the repo references JUnit 4 imports.
- Confirmed no other `pom.xml` in the repo references `junit4.version`, `junit-vintage-engine`, or the plain `junit` artifact.
- Verified `pom.xml` remains well-formed XML after the edits.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): yes (removes unused test dependencies)
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Code)

Generated-by: Claude Code (claude-sonnet-5)
